### PR TITLE
Add private OfficeJS snippets

### DIFF
--- a/config/build.ts
+++ b/config/build.ts
@@ -78,7 +78,7 @@ const defaultApiSets = {
 
 
 async function processSnippets(dir) {
-    await new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         banner('Loading & processing snippets');
         let files$ = getFiles(path.resolve(dir), path.resolve(dir));
 

--- a/config/deploy.ts
+++ b/config/deploy.ts
@@ -32,7 +32,7 @@ const environmentVariables: IEnvironmentVariables = process.env;
             shell.exec('git checkout --orphan newbranch');
             shell.exec('git reset');
 
-            execCommand('git add -f samples playlists README.md');
+            execCommand('git add -f samples playlists private-samples private-playlists README.md');
             execCommand(`git commit -m "Travis auto-deploy of ${environmentVariables.TRAVIS_COMMIT_MESSAGE.replace(/\W/g, '_')}"`);
 
             const tokenizedGitHubGitUrl = `https://<<<token>>>@github.com/${environmentVariables.GH_ACCOUNT}/${environmentVariables.GH_REPO}.git`;

--- a/private-playlists/word.yaml
+++ b/private-playlists/word.yaml
@@ -1,0 +1,11 @@
+- id: word-01-basics-basic-api-call-
+  name: Basic API call
+  fileName: basic-api-call.yaml
+  relativePath: word\01-basics\basic-api-call.yaml
+  description: Executes a basic Word API call using TypeScript.
+  host: word
+  rawUrl: >-
+    https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/private-samples/word/01-basics/basic-api-call.yaml
+  group: Basics
+  api_set:
+    WordApi: 1.1

--- a/private-samples/word/01-basics/basic-api-call.yaml
+++ b/private-samples/word/01-basics/basic-api-call.yaml
@@ -1,0 +1,94 @@
+id: word-01-basics-basic-api-call-
+name: Basic API call
+description: Executes a basic Word API call using TypeScript.
+author: OfficeDev
+host: WORD
+api_set:
+    WordApi: 1.1
+script:
+    content: |-
+        $("#run").click(() => tryCatch(run));
+
+        async function run() {
+            // Gets the current selection and changes the font color to blue.
+            await Word.run(async (context) => {
+                const range = context.document.getSelection();
+                range.font.color = "blue";
+                range.load("text");
+
+                await context.sync();
+
+                console.log(`The selected text was "${range.text}".`);
+            });
+        }
+
+        /** Default helper for invoking an action and handling errors. */
+        async function tryCatch(callback) {
+            try {
+                await callback();
+            }
+            catch (error) {
+                OfficeHelpers.UI.notify(error);
+                OfficeHelpers.Utilities.log(error);
+            }
+        }
+    language: typescript
+template:
+    content: |-
+        <p class="ms-font-m">Executes a simple code snippet. Make sure to select text before clicking "Run code".</p>
+        <button id="run" class="ms-Button">
+            <span class="ms-Button-label">Run code</span>
+        </button>
+    language: html
+style:
+    content: |-
+        body {
+            margin: 0;
+            padding: 10px;
+        }
+
+
+        /* Button customization, including overwriting some Fabric defaults */
+
+        .ms-Button, .ms-Button:focus {
+            background: #2b579a;
+            border: #2b579a;
+        }
+
+            .ms-Button > .ms-Button-label,
+            .ms-Button:focus > .ms-Button-label,
+            .ms-Button:hover > .ms-Button-label {
+                color: white;
+            }
+
+            .ms-Button:hover, .ms-Button:active {
+                background: #204072;
+            }
+
+            .ms-Button.is-disabled, .ms-Button:disabled {
+                background-color: #f4f4f4;
+                border-color: #f4f4f4;
+            }
+
+            .ms-Button.is-disabled .ms-Button-label,
+            .ms-Button:disabled .ms-Button-label {
+                color: #a6a6a6;
+            }
+    language: css
+libraries: |-
+    // Office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+
+    // NPM libraries
+    jquery@3.1.1
+    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
+    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
+    core-js@2.4.1/client/core.min.js
+
+    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
+    @types/office-js
+    @types/jquery
+    @types/core-js
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts


### PR DESCRIPTION
OfficeJS now has private snippets, which are independent of the old playlists (now treated as 'public') and will not be included as defaults in applications such as Script Lab.

The directory structure remains the same: under `private-samples` choose the appropriate `host`, add a subdirectory denoting what type of snippet it is, and then add the snippet name. A sample Word snippet is included in this pull request.