### PR TITLE
Prevent build.ts from overwriting office.js in outlook snippets

### DIFF
--- a/config/build.ts
+++ b/config/build.ts
@@ -237,7 +237,8 @@ async function processSnippets(processedSnippets) {
             throw new Error(`Cannot have more than one reference to Office.js or ${officeDTS}`);
         }
 
-        if (officeJsReferences[0] !== canonicalOfficeJsReference) {
+        // for now, outlook does not want to use cannonical Office.js due to a bug.
+        if (officeJsReferences[0] !== canonicalOfficeJsReference && host.toUpperCase() !== 'OUTLOOK') {
             messages.push(`Office.js reference "${officeJsReferences[0]}" is not in the canonical form of "${canonicalOfficeJsReference}". Fixing it.`);
             snippet.libraries = snippet.libraries.replace(officeJsReferences[0], canonicalOfficeJsReference);
         }

--- a/config/build.ts
+++ b/config/build.ts
@@ -237,7 +237,7 @@ async function processSnippets(processedSnippets) {
             throw new Error(`Cannot have more than one reference to Office.js or ${officeDTS}`);
         }
 
-        // for now, outlook does not want to use cannonical Office.js due to a bug.
+        // for now, outlook does not want to use cannonical Office.js due to bug #65.
         if (officeJsReferences[0] !== canonicalOfficeJsReference && host.toUpperCase() !== 'OUTLOOK') {
             messages.push(`Office.js reference "${officeJsReferences[0]}" is not in the canonical form of "${canonicalOfficeJsReference}". Fixing it.`);
             snippet.libraries = snippet.libraries.replace(officeJsReferences[0], canonicalOfficeJsReference);

--- a/playlists/outlook.yaml
+++ b/playlists/outlook.yaml
@@ -1,9 +1,7 @@
 - id: outlook-01-compose-basics-get-item-subject
   name: Get Item Subject
   fileName: get-item-subject.yaml
-  relativePath: outlook\01-compose-basics\get-item-subject.yaml
   description: Gets the subject of a compose item
-  host: outlook
   rawUrl: >-
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/outlook/01-compose-basics/get-item-subject.yaml
   group: Compose Basics
@@ -11,9 +9,7 @@
 - id: outlook-01-compose-basics-get-selected-text
   name: Get Selected Text
   fileName: get-selected-text.yaml
-  relativePath: outlook\01-compose-basics\get-selected-text.yaml
   description: Outputs the text selected from either the body or subject.
-  host: outlook
   rawUrl: >-
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/outlook/01-compose-basics/get-selected-text.yaml
   group: Compose Basics
@@ -21,9 +17,7 @@
 - id: outlook-01-compose-basics-set-selected-text
   name: Set Selected Text
   fileName: set-selected-text.yaml
-  relativePath: outlook\01-compose-basics\set-selected-text.yaml
   description: Changes the value of selected text in body or subject.
-  host: outlook
   rawUrl: >-
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/outlook/01-compose-basics/set-selected-text.yaml
   group: Compose Basics

--- a/view/outlook.json
+++ b/view/outlook.json
@@ -1,0 +1,5 @@
+{
+  "outlook-01-compose-basics-get-item-subject": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/outlook/01-compose-basics/get-item-subject.yaml",
+  "outlook-01-compose-basics-get-selected-text": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/outlook/01-compose-basics/get-selected-text.yaml",
+  "outlook-01-compose-basics-set-selected-text": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/outlook/01-compose-basics/set-selected-text.yaml"
+}


### PR DESCRIPTION
Noticed that npm start was overwriting the custom office.js