### PR TITLE
Moving JS references next to their corresponding d.ts files.

### DIFF
--- a/samples/excel/01-basics/basic-api-call-es5.yaml
+++ b/samples/excel/01-basics/basic-api-call-es5.yaml
@@ -43,20 +43,17 @@ style:
     content: ''
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/01-basics/basic-api-call.yaml
+++ b/samples/excel/01-basics/basic-api-call.yaml
@@ -44,20 +44,17 @@ style:
     content: ''
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/01-basics/basic-common-api-call.yaml
+++ b/samples/excel/01-basics/basic-common-api-call.yaml
@@ -30,20 +30,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/default.yaml
+++ b/samples/excel/default.yaml
@@ -39,20 +39,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/onenote/default.yaml
+++ b/samples/onenote/default.yaml
@@ -39,20 +39,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/outlook/01-compose-basics/get-item-subject.yaml
+++ b/samples/outlook/01-compose-basics/get-item-subject.yaml
@@ -29,19 +29,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js 
+    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
+    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/outlook/01-compose-basics/get-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/get-selected-text.yaml
@@ -29,19 +29,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js 
+    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
+    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/outlook/01-compose-basics/set-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/set-selected-text.yaml
@@ -27,19 +27,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js 
+    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
+    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/powerpoint/basics/basic-common-api-call.yaml
+++ b/samples/powerpoint/basics/basic-common-api-call.yaml
@@ -30,20 +30,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/powerpoint/basics/get-slide-metadata.yaml
+++ b/samples/powerpoint/basics/get-slide-metadata.yaml
@@ -33,20 +33,18 @@ template:
 style:
     content: "body {\r\n    margin: 0;\r\n    padding: 10px;\r\n}\r\n\r\n\r\n/* Button customization, including overwriting some Fabric defaults */\r\n\r\n.ms-Button, .ms-Button:focus {\r\n    background: #b7472a;\r\n    border: #b7472a;\r\n}\r\n\r\n    .ms-Button > .ms-Button-label,\r\n    .ms-Button:focus > .ms-Button-label,\r\n    .ms-Button:hover > .ms-Button-label {\r\n        color: white;\r\n    }\r\n\r\n    .ms-Button:hover, .ms-Button:active {\r\n        background: #8e3720;\r\n    }\r\n\r\n    .ms-Button.is-disabled, .ms-Button:disabled {\r\n        background-color: #f4f4f4;\r\n        border-color: #f4f4f4;\r\n    }\r\n\r\n    .ms-Button.is-disabled .ms-Button-label,\r\n    .ms-Button:disabled .ms-Button-label {\r\n        color: #a6a6a6;\r\n    }\r\n\r\n    "
     language: css
-libraries: |-
-    // Office.js
+libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/powerpoint/basics/insert-image.yaml
+++ b/samples/powerpoint/basics/insert-image.yaml
@@ -40,20 +40,18 @@ template:
 style:
     content: "body {\r\n    margin: 0;\r\n    padding: 10px;\r\n}\r\n\r\n\r\n/* Button customization, including overwriting some Fabric defaults */\r\n\r\n.ms-Button, .ms-Button:focus {\r\n    background: #b7472a;\r\n    border: #b7472a;\r\n}\r\n\r\n    .ms-Button > .ms-Button-label,\r\n    .ms-Button:focus > .ms-Button-label,\r\n    .ms-Button:hover > .ms-Button-label {\r\n        color: white;\r\n    }\r\n\r\n    .ms-Button:hover, .ms-Button:active {\r\n        background: #8e3720;\r\n    }\r\n\r\n    .ms-Button.is-disabled, .ms-Button:disabled {\r\n        background-color: #f4f4f4;\r\n        border-color: #f4f4f4;\r\n    }\r\n\r\n    .ms-Button.is-disabled .ms-Button-label,\r\n    .ms-Button:disabled .ms-Button-label {\r\n        color: #a6a6a6;\r\n    }"
     language: css
-libraries: |-
-    // Office.js
+libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/powerpoint/default.yaml
+++ b/samples/powerpoint/default.yaml
@@ -28,20 +28,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/project/basics/basic-common-api-call.yaml
+++ b/samples/project/basics/basic-common-api-call.yaml
@@ -30,20 +30,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/project/default.yaml
+++ b/samples/project/default.yaml
@@ -28,20 +28,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/web/default.yaml
+++ b/samples/web/default.yaml
@@ -22,16 +22,14 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/word/01-basics/basic-api-call-es5.yaml
+++ b/samples/word/01-basics/basic-api-call-es5.yaml
@@ -75,20 +75,18 @@ style:
                 color: #a6a6a6;
             }
     language: css
-libraries: |-
-    // Office.js
+libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/01-basics/basic-api-call.yaml
+++ b/samples/word/01-basics/basic-api-call.yaml
@@ -76,20 +76,18 @@ style:
                 color: #a6a6a6;
             }
     language: css
-libraries: |-
-    // Office.js
+libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/01-basics/basic-common-api-call.yaml
+++ b/samples/word/01-basics/basic-common-api-call.yaml
@@ -30,20 +30,17 @@ style:
     content: "/* Your style goes here */\r\n"
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/word/default.yaml
+++ b/samples/word/default.yaml
@@ -40,20 +40,17 @@ style:
         /* Your style goes here */
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery


### PR DESCRIPTION
This is something that's become more and more apparent with folks using non-canonical Office.js (e.g., beta, or unpkg private/alpha versions).  Needing to replace things at 2 different spots in the file is harder than just one place.

I think re-ordering would make it much simpler to do these sorts of changes.

Note that I'm doing this for only a subset of samples for now (all the basic/default one).  Will let someone else go through the rest, though that work is likely just an hour or so (and can be done alongside the other cleanup).  It should essentially be just a copy-paste, making sure to adjust for the few samples that do make use of other libraries.  This remaining cleanup work is tracked as part of https://github.com/OfficeDev/office-js-snippets/issues/81

You can skip over the `build.ts` change, this was to make validation be more accurate.  The real change is just replacing the libraries section of each snippet with:

    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts

    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

    core-js@2.4.1/client/core.min.js
    @types/core-js

    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts

    jquery@3.1.1
    @types/jquery