### PR TITLE
Update yaml and folder for multiple-property-set (Word) snippet.

### DIFF
--- a/playlists/word.yaml
+++ b/playlists/word.yaml
@@ -182,10 +182,10 @@
   fileName: multiple-property-set.yaml
   description: Setting multiple properties at once with the API object set() method.
   rawUrl: >-
-    https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/50-preview-apis/multiple-property-set.yaml
-  group: Preview APIs
+    https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/50-common-patterns/multiple-property-set.yaml
+  group: Common Patterns
   api_set:
-    WordApi: 1.4
+    WordApi: 1.3
 - id: word-fabric-insert-form-data
   name: Fabric JS - Using form data
   fileName: fabric-insert-form-data.yaml

--- a/samples/word/50-common-patterns/multiple-property-set.yaml
+++ b/samples/word/50-common-patterns/multiple-property-set.yaml
@@ -3,7 +3,7 @@ name: Multiple Property Set
 description: Setting multiple properties at once with the API object set() method.
 host: WORD
 api_set:
-    WordApi: 1.4
+    WordApi: 1.3
 script:
     content: |-
         $("#set-multiple-properties-with-object").click(() => tryCatch(setMultiplePropertiesWithObject));
@@ -104,8 +104,8 @@ style:
             }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/view/word.json
+++ b/view/word.json
@@ -18,6 +18,6 @@
   "word-lists-insert-list": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/06-lists/insert-list.yaml",
   "word-basics-read-write-custom-document-properties": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/07-custom-properties/read-write-custom-document-properties.yaml",
   "word-custom-properties-get-built-in-properties": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/07-custom-properties/get-built-in-properties.yaml",
-  "word-common-patterns-multiple-property-set": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/50-preview-apis/multiple-property-set.yaml",
+  "word-common-patterns-multiple-property-set": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/50-common-patterns/multiple-property-set.yaml",
   "word-fabric-insert-form-data": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/99-fabric/fabric-insert-form-data.yaml"
 }


### PR DESCRIPTION
Since this snippet does not use any Preview APIs, I made the following changes:

- Set the required requirement set (back) to 1.3.
- Reference the prod Office.js library and prod Office.d.ts (instead of beta).
- Move the snippet (back) into the 50-common-patterns folder.