### PR TITLE
Pointing snippets at DefinitelyTyped and reorging libraries

### DIFF
--- a/samples/excel/01-basics/basic-api-call-es5.yaml
+++ b/samples/excel/01-basics/basic-api-call-es5.yaml
@@ -44,7 +44,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/01-basics/basic-api-call.yaml
+++ b/samples/excel/01-basics/basic-api-call.yaml
@@ -45,7 +45,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/01-basics/basic-common-api-call.yaml
+++ b/samples/excel/01-basics/basic-common-api-call.yaml
@@ -32,7 +32,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/20-scenarios/report-generation.yaml
+++ b/samples/excel/20-scenarios/report-generation.yaml
@@ -149,20 +149,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/conditional-formatting-advanced.yaml
+++ b/samples/excel/30-range/conditional-formatting-advanced.yaml
@@ -263,20 +263,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.6.0/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
-    @microsoft/office-js-helpers/dist/office.helpers.d.ts
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/conditional-formatting-basic.yaml
+++ b/samples/excel/30-range/conditional-formatting-basic.yaml
@@ -363,20 +363,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.6.0/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
-    @microsoft/office-js-helpers/dist/office.helpers.d.ts
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/copy-multiply-values.yaml
+++ b/samples/excel/30-range/copy-multiply-values.yaml
@@ -163,20 +163,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/create-and-use-range-intersection.yaml
+++ b/samples/excel/30-range/create-and-use-range-intersection.yaml
@@ -146,20 +146,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/formatting.yaml
+++ b/samples/excel/30-range/formatting.yaml
@@ -118,20 +118,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/insert-delete-clear-range.yaml
+++ b/samples/excel/30-range/insert-delete-clear-range.yaml
@@ -137,20 +137,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/range-hyperlink.yaml
+++ b/samples/excel/30-range/range-hyperlink.yaml
@@ -326,7 +326,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/30-range/range-operations.yaml
+++ b/samples/excel/30-range/range-operations.yaml
@@ -163,20 +163,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/range-text-orientation.yaml
+++ b/samples/excel/30-range/range-text-orientation.yaml
@@ -115,7 +115,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/30-range/selected-range.yaml
+++ b/samples/excel/30-range/selected-range.yaml
@@ -75,20 +75,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/set-get-values.yaml
+++ b/samples/excel/30-range/set-get-values.yaml
@@ -274,20 +274,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/test-for-used-range.yaml
+++ b/samples/excel/30-range/test-for-used-range.yaml
@@ -108,20 +108,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/30-range/working-with-dates.yaml
+++ b/samples/excel/30-range/working-with-dates.yaml
@@ -142,22 +142,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-    moment@2.18.1
-    moment-msdate@0.2.2
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/35-worksheet/activeworksheet.yaml
+++ b/samples/excel/35-worksheet/activeworksheet.yaml
@@ -126,20 +126,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/35-worksheet/add-delete-rename-move-worksheet.yaml
+++ b/samples/excel/35-worksheet/add-delete-rename-move-worksheet.yaml
@@ -152,20 +152,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/35-worksheet/hide-unhide-worksheet.yaml
+++ b/samples/excel/35-worksheet/hide-unhide-worksheet.yaml
@@ -99,20 +99,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/35-worksheet/list-worksheets.yaml
+++ b/samples/excel/35-worksheet/list-worksheets.yaml
@@ -61,20 +61,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/35-worksheet/reference-worksheets-by-relative-position.yaml
+++ b/samples/excel/35-worksheet/reference-worksheets-by-relative-position.yaml
@@ -157,20 +157,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/35-worksheet/tab-color.yaml
+++ b/samples/excel/35-worksheet/tab-color.yaml
@@ -103,7 +103,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/35-worksheet/worksheet-copy.yaml
+++ b/samples/excel/35-worksheet/worksheet-copy.yaml
@@ -92,7 +92,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/35-worksheet/worksheet-freeze-panes.yaml
+++ b/samples/excel/35-worksheet/worksheet-freeze-panes.yaml
@@ -173,7 +173,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/35-worksheet/worksheet-range-cell.yaml
+++ b/samples/excel/35-worksheet/worksheet-range-cell.yaml
@@ -161,20 +161,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/37-workbook/protect-data-in-worksheet-and-workbook-structure.yaml
+++ b/samples/excel/37-workbook/protect-data-in-worksheet-and-workbook-structure.yaml
@@ -247,7 +247,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/37-workbook/workbook-get-active-cell.yaml
+++ b/samples/excel/37-workbook/workbook-get-active-cell.yaml
@@ -52,7 +52,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/40-table/add-rows-and-columns-to-a-table.yaml
+++ b/samples/excel/40-table/add-rows-and-columns-to-a-table.yaml
@@ -188,20 +188,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/convert-range-to-table.yaml
+++ b/samples/excel/40-table/convert-range-to-table.yaml
@@ -106,20 +106,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/create-table.yaml
+++ b/samples/excel/40-table/create-table.yaml
@@ -75,20 +75,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/filter-data.yaml
+++ b/samples/excel/40-table/filter-data.yaml
@@ -134,20 +134,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/format-table.yaml
+++ b/samples/excel/40-table/format-table.yaml
@@ -108,20 +108,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/get-data-from-table.yaml
+++ b/samples/excel/40-table/get-data-from-table.yaml
@@ -127,20 +127,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/get-visible-range-of-a-filtered-table.yaml
+++ b/samples/excel/40-table/get-visible-range-of-a-filtered-table.yaml
@@ -168,20 +168,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/import-json-data.yaml
+++ b/samples/excel/40-table/import-json-data.yaml
@@ -140,20 +140,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/sort-data.yaml
+++ b/samples/excel/40-table/sort-data.yaml
@@ -109,20 +109,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/40-table/style.yaml
+++ b/samples/excel/40-table/style.yaml
@@ -226,7 +226,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/45-named-item/create-and-remove-named-item.yaml
+++ b/samples/excel/45-named-item/create-and-remove-named-item.yaml
@@ -171,20 +171,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/45-named-item/create-and-use-named-item-for-range.yaml
+++ b/samples/excel/45-named-item/create-and-use-named-item-for-range.yaml
@@ -163,20 +163,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/45-named-item/create-named-item.yaml
+++ b/samples/excel/45-named-item/create-named-item.yaml
@@ -133,20 +133,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/45-named-item/list-named-items.yaml
+++ b/samples/excel/45-named-item/list-named-items.yaml
@@ -58,20 +58,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/45-named-item/update-named-item.yaml
+++ b/samples/excel/45-named-item/update-named-item.yaml
@@ -121,7 +121,7 @@ style:
     language: css
 libraries: |-
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-axis.yaml
+++ b/samples/excel/50-chart/chart-axis.yaml
@@ -67,7 +67,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-legend.yaml
+++ b/samples/excel/50-chart/chart-legend.yaml
@@ -136,7 +136,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-point.yaml
+++ b/samples/excel/50-chart/chart-point.yaml
@@ -122,7 +122,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-series-doughnutholesize.yaml
+++ b/samples/excel/50-chart/chart-series-doughnutholesize.yaml
@@ -124,7 +124,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-series-markers.yaml
+++ b/samples/excel/50-chart/chart-series-markers.yaml
@@ -115,7 +115,7 @@ style:
     language: css
 libraries: |-
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-series-plotorder.yaml
+++ b/samples/excel/50-chart/chart-series-plotorder.yaml
@@ -126,7 +126,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-series.yaml
+++ b/samples/excel/50-chart/chart-series.yaml
@@ -165,7 +165,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-title-substring.yaml
+++ b/samples/excel/50-chart/chart-title-substring.yaml
@@ -114,7 +114,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/chart-trendlines.yaml
+++ b/samples/excel/50-chart/chart-trendlines.yaml
@@ -192,7 +192,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/create-additional-chart-types.yaml
+++ b/samples/excel/50-chart/create-additional-chart-types.yaml
@@ -239,7 +239,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/create-column-clustered-chart.yaml
+++ b/samples/excel/50-chart/create-column-clustered-chart.yaml
@@ -117,20 +117,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/50-chart/create-doughnut-chart.yaml
+++ b/samples/excel/50-chart/create-doughnut-chart.yaml
@@ -122,20 +122,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/50-chart/create-line-chart.yaml
+++ b/samples/excel/50-chart/create-line-chart.yaml
@@ -104,7 +104,7 @@ style:
     language: css
 libraries: |-
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/50-chart/create-xyscatter-chart.yaml
+++ b/samples/excel/50-chart/create-xyscatter-chart.yaml
@@ -101,7 +101,7 @@ style:
     language: css
 libraries: |-
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/55-pivot-table/refresh-pivot-table.yaml
+++ b/samples/excel/55-pivot-table/refresh-pivot-table.yaml
@@ -120,20 +120,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/70-events/data-changed.yaml
+++ b/samples/excel/70-events/data-changed.yaml
@@ -97,20 +97,17 @@ style:
         /* Your style goes here */
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/70-events/events-table-changed.yaml
+++ b/samples/excel/70-events/events-table-changed.yaml
@@ -172,7 +172,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/70-events/events-tablecollection-changed.yaml
+++ b/samples/excel/70-events/events-tablecollection-changed.yaml
@@ -159,7 +159,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/70-events/events-worksheet-activated.yaml
+++ b/samples/excel/70-events/events-worksheet-activated.yaml
@@ -158,7 +158,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/70-events/events-worksheet-changed.yaml
+++ b/samples/excel/70-events/events-worksheet-changed.yaml
@@ -172,7 +172,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/70-events/events-worksheet-selectionchanged.yaml
+++ b/samples/excel/70-events/events-worksheet-selectionchanged.yaml
@@ -126,7 +126,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/70-events/selection-changed.yaml
+++ b/samples/excel/70-events/selection-changed.yaml
@@ -119,20 +119,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/70-events/setting-changed.yaml
+++ b/samples/excel/70-events/setting-changed.yaml
@@ -124,20 +124,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/80-settings/create-get-change-delete-settings.yaml
+++ b/samples/excel/80-settings/create-get-change-delete-settings.yaml
@@ -111,20 +111,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/82-document/get-file-in-slices-async.yaml
+++ b/samples/excel/82-document/get-file-in-slices-async.yaml
@@ -191,22 +191,19 @@ style:
         }
     language: css
 libraries: |-
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery
 
     https://unpkg.com/base64-js@1.2.1/base64js.min.js

--- a/samples/excel/82-document/properties.yaml
+++ b/samples/excel/82-document/properties.yaml
@@ -175,7 +175,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/excel/85-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
+++ b/samples/excel/85-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
@@ -146,20 +146,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/85-custom-xml-parts/test-xml-for-unique-namespace.yaml
+++ b/samples/excel/85-custom-xml-parts/test-xml-for-unique-namespace.yaml
@@ -132,20 +132,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/88-common-patterns/multiple-property-set.yaml
+++ b/samples/excel/88-common-patterns/multiple-property-set.yaml
@@ -129,20 +129,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/89-preview-apis/events-worksheet-calculated.yaml
+++ b/samples/excel/89-preview-apis/events-worksheet-calculated.yaml
@@ -105,13 +105,17 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
+
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+
     core-js@2.4.1/client/core.min.js
     @types/core-js
+
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
     jquery@3.1.1
     @types/jquery

--- a/samples/excel/90-just-for-fun/color-wheel.yaml
+++ b/samples/excel/90-just-for-fun/color-wheel.yaml
@@ -141,20 +141,17 @@ style:
         }
     language: css
 libraries: |
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    // NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    // IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/90-just-for-fun/gradient.yaml
+++ b/samples/excel/90-just-for-fun/gradient.yaml
@@ -192,22 +192,19 @@ style:
         }
     language: css
 libraries: |-
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.6.3/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
-    @microsoft/office-js-helpers/dist/office.helpers.d.ts
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery
 
     tinycolor2@1.4.1/tinycolor.js

--- a/samples/excel/90-just-for-fun/path-finder-game.yaml
+++ b/samples/excel/90-just-for-fun/path-finder-game.yaml
@@ -221,20 +221,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/90-just-for-fun/patterns.yaml
+++ b/samples/excel/90-just-for-fun/patterns.yaml
@@ -189,20 +189,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/excel/default.yaml
+++ b/samples/excel/default.yaml
@@ -41,7 +41,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/onenote/default.yaml
+++ b/samples/onenote/default.yaml
@@ -41,7 +41,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/outlook/01-compose-basics/get-item-subject.yaml
+++ b/samples/outlook/01-compose-basics/get-item-subject.yaml
@@ -31,7 +31,7 @@ style:
     language: css
 libraries: |
     https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/outlook/01-compose-basics/get-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/get-selected-text.yaml
@@ -31,7 +31,7 @@ style:
     language: css
 libraries: |
     https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/outlook/01-compose-basics/set-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/set-selected-text.yaml
@@ -29,7 +29,7 @@ style:
     language: css
 libraries: |
     https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/outlook/default.yaml
+++ b/samples/outlook/default.yaml
@@ -23,20 +23,17 @@ style:
         /* Your style goes here */
     language: css
 libraries: |
-    # Office.js
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js 
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    jquery@3.1.1
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
     @types/jquery

--- a/samples/powerpoint/basics/basic-common-api-call.yaml
+++ b/samples/powerpoint/basics/basic-common-api-call.yaml
@@ -32,7 +32,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/powerpoint/basics/get-slide-metadata.yaml
+++ b/samples/powerpoint/basics/get-slide-metadata.yaml
@@ -69,7 +69,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/powerpoint/basics/insert-image.yaml
+++ b/samples/powerpoint/basics/insert-image.yaml
@@ -74,7 +74,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/powerpoint/default.yaml
+++ b/samples/powerpoint/default.yaml
@@ -30,7 +30,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/project/basics/basic-common-api-call.yaml
+++ b/samples/project/basics/basic-common-api-call.yaml
@@ -32,7 +32,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/project/default.yaml
+++ b/samples/project/default.yaml
@@ -30,7 +30,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/word/01-basics/basic-api-call-es5.yaml
+++ b/samples/word/01-basics/basic-api-call-es5.yaml
@@ -77,7 +77,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/word/01-basics/basic-api-call.yaml
+++ b/samples/word/01-basics/basic-api-call.yaml
@@ -78,7 +78,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/word/01-basics/basic-common-api-call.yaml
+++ b/samples/word/01-basics/basic-common-api-call.yaml
@@ -32,7 +32,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/word/01-basics/basic-doc-assembly.yaml
+++ b/samples/word/01-basics/basic-doc-assembly.yaml
@@ -204,7 +204,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/word/01-basics/insert-and-get-pictures.yaml
+++ b/samples/word/01-basics/insert-and-get-pictures.yaml
@@ -146,21 +146,17 @@ style:
         }
     language: css
 libraries: |
-    # Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    # CSS Libraries
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
 
-    # NPM libraries
     core-js@2.4.1/client/core.min.js
-    @microsoft/office-js-helpers@.5.0/dist/office.helpers.min.js
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
-
-    # IntelliSense: @types/library or node_modules paths or URL to d.ts files
-    @types/office-js
-    @types/jquery
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/01-basics/insert-formatted-text.yaml
+++ b/samples/word/01-basics/insert-formatted-text.yaml
@@ -95,19 +95,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/01-basics/insert-header.yaml
+++ b/samples/word/01-basics/insert-header.yaml
@@ -73,19 +73,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/01-basics/insert-line-and-page-breaks.yaml
+++ b/samples/word/01-basics/insert-line-and-page-breaks.yaml
@@ -136,19 +136,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/01-basics/search.yaml
+++ b/samples/word/01-basics/search.yaml
@@ -150,19 +150,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/02-paragraphs/get-paragraph-on-insertion-point.yaml
+++ b/samples/word/02-paragraphs/get-paragraph-on-insertion-point.yaml
@@ -151,19 +151,17 @@ style:
         }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/02-paragraphs/insert-in-different-locations.yaml
+++ b/samples/word/02-paragraphs/insert-in-different-locations.yaml
@@ -188,19 +188,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/02-paragraphs/paragraph-properties.yaml
+++ b/samples/word/02-paragraphs/paragraph-properties.yaml
@@ -165,19 +165,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/03-content-controls/insert-and-change-content-controls.yaml
+++ b/samples/word/03-content-controls/insert-and-change-content-controls.yaml
@@ -176,19 +176,17 @@ style:
         }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/04-range/scroll-to-range.yaml
+++ b/samples/word/04-range/scroll-to-range.yaml
@@ -137,19 +137,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/04-range/split-words-of-first-paragraph.yaml
+++ b/samples/word/04-range/split-words-of-first-paragraph.yaml
@@ -90,7 +90,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/word/05-tables/table-cell-access.yaml
+++ b/samples/word/05-tables/table-cell-access.yaml
@@ -121,19 +121,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/06-lists/insert-list.yaml
+++ b/samples/word/06-lists/insert-list.yaml
@@ -133,19 +133,17 @@ style:
         }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/07-custom-properties/get-built-in-properties.yaml
+++ b/samples/word/07-custom-properties/get-built-in-properties.yaml
@@ -74,19 +74,17 @@ style:
             }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/07-custom-properties/read-write-custom-document-properties.yaml
+++ b/samples/word/07-custom-properties/read-write-custom-document-properties.yaml
@@ -129,19 +129,17 @@ style:
                 }
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/50-common-patterns/multiple-property-set.yaml
+++ b/samples/word/50-common-patterns/multiple-property-set.yaml
@@ -105,7 +105,7 @@ style:
     language: css
 libraries: |-
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css

--- a/samples/word/99-fabric/fabric-insert-form-data.yaml
+++ b/samples/word/99-fabric/fabric-insert-form-data.yaml
@@ -193,19 +193,17 @@ style:
     content: ''
     language: css
 libraries: |-
-    // Office.js
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
 
-    // NPM libraries
-    jquery@3.1.1
-    office-ui-fabric-js@1.4.0/dist/js/fabric.min.js
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
-    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
-    core-js@2.4.1/client/core.min.js
 
-    // IntelliSense: Use dt~library_name for DefinitelyTyped or URLs to d.ts files
-    @types/office-js
-    @types/jquery
+    core-js@2.4.1/client/core.min.js
     @types/core-js
+
+    @microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
+
+    jquery@3.1.1
+    @types/jquery

--- a/samples/word/default.yaml
+++ b/samples/word/default.yaml
@@ -41,7 +41,7 @@ style:
     language: css
 libraries: |
     https://appsforoffice.microsoft.com/lib/1/hosted/office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.d.ts
+    @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
     office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css


### PR DESCRIPTION
DefinitelyTyped is more up to date than the CDN. All the GA snippets should point there for Intellisense.

I've also reorganized the library sections based on the work started with [PR 82](https://github.com/OfficeDev/office-js-snippets/pull/82).