### PR TITLE
Correcting sample to follow product team guidance

### DIFF
--- a/samples/excel/82-document/get-file-in-slices-async.yaml
+++ b/samples/excel/82-document/get-file-in-slices-async.yaml
@@ -83,11 +83,11 @@ script:
             }
         }
 
-        // Note: this function uses preview APIs. Switch to the beta libraries to use Application.createWorkbook().
+        // Note: this function uses preview APIs. Switch to the beta libraries to use CreateWorkbook().
         async function newWorkbookFromFile() {
-            await Excel.run(async (context) => {
-                // create a new workbook from the TextArea and open it
-                context.application.createWorkbook($('#file-contents').text()).open();
+            await Excel.createWorkbook($('#file-contents').text()).catch(function (error) {
+                OfficeHelpers.UI.notify(error);
+                OfficeHelpers.Utilities.log(error);
             });
         }
 


### PR DESCRIPTION
Here's the email text from Jipeng:

@Alexander Jerabek For the createworkbook API, the context.application.createWorkbook().open(); is not suggested to be used by user.

Instead we have changed to the following way, where can we put the documentation? Thanks.

Excel.createWorkbook(base64).catch(function (error) {
                app.showNotification(error.code, error.message);
                if (error instanceof OfficeExtension.Error) {
                    app.showNotification("Debug info: ", JSON.stringify(error.debugInfo));
                }
            });
