### PR TITLE
Fix for jQuery Intellisense in Script Lab

### DIFF
--- a/private-samples/excel/20-chart/chart-title-js.yaml
+++ b/private-samples/excel/20-chart/chart-title-js.yaml
@@ -149,4 +149,4 @@ libraries: |
     @types/office-js
     @types/core-js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
-    @types/jquery
+    @types/jquery@3.1.1

--- a/private-samples/excel/20-chart/chart-title-ts.yaml
+++ b/private-samples/excel/20-chart/chart-title-ts.yaml
@@ -147,4 +147,4 @@ libraries: |
     @types/office-js
     @types/core-js
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/01-basics/basic-api-call-es5.yaml
+++ b/samples/excel/01-basics/basic-api-call-es5.yaml
@@ -56,4 +56,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/01-basics/basic-api-call.yaml
+++ b/samples/excel/01-basics/basic-api-call.yaml
@@ -57,4 +57,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/01-basics/basic-common-api-call.yaml
+++ b/samples/excel/01-basics/basic-common-api-call.yaml
@@ -44,4 +44,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/20-scenarios/report-generation.yaml
+++ b/samples/excel/20-scenarios/report-generation.yaml
@@ -162,4 +162,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/conditional-formatting-advanced.yaml
+++ b/samples/excel/30-range/conditional-formatting-advanced.yaml
@@ -276,4 +276,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/conditional-formatting-basic.yaml
+++ b/samples/excel/30-range/conditional-formatting-basic.yaml
@@ -394,4 +394,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/copy-multiply-values.yaml
+++ b/samples/excel/30-range/copy-multiply-values.yaml
@@ -176,4 +176,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/create-and-use-range-intersection.yaml
+++ b/samples/excel/30-range/create-and-use-range-intersection.yaml
@@ -159,4 +159,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/formatting.yaml
+++ b/samples/excel/30-range/formatting.yaml
@@ -131,4 +131,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/insert-delete-clear-range.yaml
+++ b/samples/excel/30-range/insert-delete-clear-range.yaml
@@ -150,4 +150,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/range-hyperlink.yaml
+++ b/samples/excel/30-range/range-hyperlink.yaml
@@ -338,4 +338,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/range-operations.yaml
+++ b/samples/excel/30-range/range-operations.yaml
@@ -176,4 +176,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/range-text-orientation.yaml
+++ b/samples/excel/30-range/range-text-orientation.yaml
@@ -127,4 +127,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/selected-range.yaml
+++ b/samples/excel/30-range/selected-range.yaml
@@ -88,4 +88,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/set-get-values.yaml
+++ b/samples/excel/30-range/set-get-values.yaml
@@ -287,4 +287,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/test-for-used-range.yaml
+++ b/samples/excel/30-range/test-for-used-range.yaml
@@ -121,4 +121,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/30-range/working-with-dates.yaml
+++ b/samples/excel/30-range/working-with-dates.yaml
@@ -155,7 +155,7 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1
 
     moment@2.18.1 
     moment-msdate@0.2.2 

--- a/samples/excel/35-worksheet/activeworksheet.yaml
+++ b/samples/excel/35-worksheet/activeworksheet.yaml
@@ -139,4 +139,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/add-delete-rename-move-worksheet.yaml
+++ b/samples/excel/35-worksheet/add-delete-rename-move-worksheet.yaml
@@ -165,4 +165,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/data-validation.yaml
+++ b/samples/excel/35-worksheet/data-validation.yaml
@@ -173,4 +173,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/hide-unhide-worksheet.yaml
+++ b/samples/excel/35-worksheet/hide-unhide-worksheet.yaml
@@ -112,4 +112,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/list-worksheets.yaml
+++ b/samples/excel/35-worksheet/list-worksheets.yaml
@@ -74,4 +74,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/reference-worksheets-by-relative-position.yaml
+++ b/samples/excel/35-worksheet/reference-worksheets-by-relative-position.yaml
@@ -170,4 +170,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/tab-color.yaml
+++ b/samples/excel/35-worksheet/tab-color.yaml
@@ -115,4 +115,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/worksheet-copy.yaml
+++ b/samples/excel/35-worksheet/worksheet-copy.yaml
@@ -104,4 +104,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/worksheet-freeze-panes.yaml
+++ b/samples/excel/35-worksheet/worksheet-freeze-panes.yaml
@@ -185,4 +185,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/worksheet-gridlines.yaml
+++ b/samples/excel/35-worksheet/worksheet-gridlines.yaml
@@ -85,4 +85,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/35-worksheet/worksheet-range-cell.yaml
+++ b/samples/excel/35-worksheet/worksheet-range-cell.yaml
@@ -174,4 +174,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/37-workbook/protect-data-in-worksheet-and-workbook-structure.yaml
+++ b/samples/excel/37-workbook/protect-data-in-worksheet-and-workbook-structure.yaml
@@ -259,4 +259,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/37-workbook/workbook-get-active-cell.yaml
+++ b/samples/excel/37-workbook/workbook-get-active-cell.yaml
@@ -64,4 +64,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/add-rows-and-columns-to-a-table.yaml
+++ b/samples/excel/40-table/add-rows-and-columns-to-a-table.yaml
@@ -201,4 +201,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/convert-range-to-table.yaml
+++ b/samples/excel/40-table/convert-range-to-table.yaml
@@ -119,4 +119,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/create-table.yaml
+++ b/samples/excel/40-table/create-table.yaml
@@ -88,4 +88,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/filter-data.yaml
+++ b/samples/excel/40-table/filter-data.yaml
@@ -147,4 +147,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/format-table.yaml
+++ b/samples/excel/40-table/format-table.yaml
@@ -121,4 +121,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/get-data-from-table.yaml
+++ b/samples/excel/40-table/get-data-from-table.yaml
@@ -140,4 +140,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/get-visible-range-of-a-filtered-table.yaml
+++ b/samples/excel/40-table/get-visible-range-of-a-filtered-table.yaml
@@ -181,4 +181,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/import-json-data.yaml
+++ b/samples/excel/40-table/import-json-data.yaml
@@ -153,4 +153,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/sort-data.yaml
+++ b/samples/excel/40-table/sort-data.yaml
@@ -122,4 +122,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/40-table/style.yaml
+++ b/samples/excel/40-table/style.yaml
@@ -238,4 +238,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/45-named-item/create-and-remove-named-item.yaml
+++ b/samples/excel/45-named-item/create-and-remove-named-item.yaml
@@ -184,4 +184,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/45-named-item/create-and-use-named-item-for-range.yaml
+++ b/samples/excel/45-named-item/create-and-use-named-item-for-range.yaml
@@ -176,4 +176,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/45-named-item/create-named-item.yaml
+++ b/samples/excel/45-named-item/create-named-item.yaml
@@ -146,4 +146,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/45-named-item/list-named-items.yaml
+++ b/samples/excel/45-named-item/list-named-items.yaml
@@ -71,4 +71,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/45-named-item/update-named-item.yaml
+++ b/samples/excel/45-named-item/update-named-item.yaml
@@ -133,4 +133,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-axis-formatting.yaml
+++ b/samples/excel/50-chart/chart-axis-formatting.yaml
@@ -177,4 +177,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-axis.yaml
+++ b/samples/excel/50-chart/chart-axis.yaml
@@ -79,4 +79,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-formatting.yaml
+++ b/samples/excel/50-chart/chart-formatting.yaml
@@ -307,4 +307,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-legend.yaml
+++ b/samples/excel/50-chart/chart-legend.yaml
@@ -148,4 +148,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-point.yaml
+++ b/samples/excel/50-chart/chart-point.yaml
@@ -134,4 +134,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-series-doughnutholesize.yaml
+++ b/samples/excel/50-chart/chart-series-doughnutholesize.yaml
@@ -136,4 +136,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-series-markers.yaml
+++ b/samples/excel/50-chart/chart-series-markers.yaml
@@ -127,4 +127,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-series-plotorder.yaml
+++ b/samples/excel/50-chart/chart-series-plotorder.yaml
@@ -138,4 +138,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-series.yaml
+++ b/samples/excel/50-chart/chart-series.yaml
@@ -177,4 +177,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-title-substring.yaml
+++ b/samples/excel/50-chart/chart-title-substring.yaml
@@ -126,4 +126,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/chart-trendlines.yaml
+++ b/samples/excel/50-chart/chart-trendlines.yaml
@@ -204,4 +204,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/create-additional-chart-types.yaml
+++ b/samples/excel/50-chart/create-additional-chart-types.yaml
@@ -251,4 +251,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/create-column-clustered-chart.yaml
+++ b/samples/excel/50-chart/create-column-clustered-chart.yaml
@@ -130,4 +130,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/create-doughnut-chart.yaml
+++ b/samples/excel/50-chart/create-doughnut-chart.yaml
@@ -135,4 +135,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/create-line-chart.yaml
+++ b/samples/excel/50-chart/create-line-chart.yaml
@@ -116,4 +116,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/50-chart/create-xyscatter-chart.yaml
+++ b/samples/excel/50-chart/create-xyscatter-chart.yaml
@@ -113,4 +113,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/55-pivottable/pivottable-calculations.yaml
+++ b/samples/excel/55-pivottable/pivottable-calculations.yaml
@@ -212,4 +212,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/55-pivottable/pivottable-create-and-modify.yaml
+++ b/samples/excel/55-pivottable/pivottable-create-and-modify.yaml
@@ -275,4 +275,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/55-pivottable/pivottable-filters-and-summaries.yaml
+++ b/samples/excel/55-pivottable/pivottable-filters-and-summaries.yaml
@@ -230,4 +230,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/55-pivottable/refresh-pivot-table.yaml
+++ b/samples/excel/55-pivottable/refresh-pivot-table.yaml
@@ -133,4 +133,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/data-changed.yaml
+++ b/samples/excel/70-events/data-changed.yaml
@@ -110,4 +110,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-chart-activated.yaml
+++ b/samples/excel/70-events/events-chart-activated.yaml
@@ -163,4 +163,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-chartcollection-added-activated.yaml
+++ b/samples/excel/70-events/events-chartcollection-added-activated.yaml
@@ -155,4 +155,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-disable-events.yaml
+++ b/samples/excel/70-events/events-disable-events.yaml
@@ -174,4 +174,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-table-changed.yaml
+++ b/samples/excel/70-events/events-table-changed.yaml
@@ -184,4 +184,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-tablecollection-changed.yaml
+++ b/samples/excel/70-events/events-tablecollection-changed.yaml
@@ -171,4 +171,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-worksheet-activated.yaml
+++ b/samples/excel/70-events/events-worksheet-activated.yaml
@@ -170,4 +170,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-worksheet-calculated.yaml
+++ b/samples/excel/70-events/events-worksheet-calculated.yaml
@@ -118,4 +118,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-worksheet-changed.yaml
+++ b/samples/excel/70-events/events-worksheet-changed.yaml
@@ -184,4 +184,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-worksheet-selectionchanged.yaml
+++ b/samples/excel/70-events/events-worksheet-selectionchanged.yaml
@@ -138,4 +138,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/events-worksheetcollection-calculated.yaml
+++ b/samples/excel/70-events/events-worksheetcollection-calculated.yaml
@@ -156,4 +156,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/selection-changed.yaml
+++ b/samples/excel/70-events/selection-changed.yaml
@@ -132,4 +132,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/70-events/setting-changed.yaml
+++ b/samples/excel/70-events/setting-changed.yaml
@@ -137,4 +137,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/80-settings/create-get-change-delete-settings.yaml
+++ b/samples/excel/80-settings/create-get-change-delete-settings.yaml
@@ -124,4 +124,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/82-document/get-file-in-slices-async.yaml
+++ b/samples/excel/82-document/get-file-in-slices-async.yaml
@@ -225,6 +225,6 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1
 
     https://unpkg.com/base64-js@1.2.1/base64js.min.js

--- a/samples/excel/82-document/properties.yaml
+++ b/samples/excel/82-document/properties.yaml
@@ -187,4 +187,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/85-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
+++ b/samples/excel/85-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
@@ -159,4 +159,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/85-custom-xml-parts/test-xml-for-unique-namespace.yaml
+++ b/samples/excel/85-custom-xml-parts/test-xml-for-unique-namespace.yaml
@@ -145,4 +145,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/88-common-patterns/multiple-property-set.yaml
+++ b/samples/excel/88-common-patterns/multiple-property-set.yaml
@@ -142,4 +142,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/89-preview-apis/range-areas.yaml
+++ b/samples/excel/89-preview-apis/range-areas.yaml
@@ -184,4 +184,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/89-preview-apis/range-copyfrom.yaml
+++ b/samples/excel/89-preview-apis/range-copyfrom.yaml
@@ -197,4 +197,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/90-just-for-fun/color-wheel.yaml
+++ b/samples/excel/90-just-for-fun/color-wheel.yaml
@@ -154,4 +154,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/90-just-for-fun/gradient.yaml
+++ b/samples/excel/90-just-for-fun/gradient.yaml
@@ -205,7 +205,7 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1
 
     tinycolor2@1.4.1/tinycolor.js
     @types/tinycolor2

--- a/samples/excel/90-just-for-fun/path-finder-game.yaml
+++ b/samples/excel/90-just-for-fun/path-finder-game.yaml
@@ -234,4 +234,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/90-just-for-fun/patterns.yaml
+++ b/samples/excel/90-just-for-fun/patterns.yaml
@@ -202,4 +202,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/excel/default.yaml
+++ b/samples/excel/default.yaml
@@ -53,4 +53,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/onenote/default.yaml
+++ b/samples/onenote/default.yaml
@@ -53,4 +53,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/outlook/01-compose-basics/get-item-subject.yaml
+++ b/samples/outlook/01-compose-basics/get-item-subject.yaml
@@ -43,4 +43,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/outlook/01-compose-basics/get-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/get-selected-text.yaml
@@ -43,4 +43,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/outlook/01-compose-basics/set-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/set-selected-text.yaml
@@ -41,4 +41,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/outlook/default.yaml
+++ b/samples/outlook/default.yaml
@@ -36,4 +36,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/powerpoint/basics/basic-common-api-call.yaml
+++ b/samples/powerpoint/basics/basic-common-api-call.yaml
@@ -44,4 +44,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/powerpoint/basics/get-slide-metadata.yaml
+++ b/samples/powerpoint/basics/get-slide-metadata.yaml
@@ -81,4 +81,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/powerpoint/basics/insert-image.yaml
+++ b/samples/powerpoint/basics/insert-image.yaml
@@ -86,4 +86,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/powerpoint/default.yaml
+++ b/samples/powerpoint/default.yaml
@@ -42,4 +42,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/project/basics/basic-common-api-call.yaml
+++ b/samples/project/basics/basic-common-api-call.yaml
@@ -44,4 +44,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/project/default.yaml
+++ b/samples/project/default.yaml
@@ -42,4 +42,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/web/default.yaml
+++ b/samples/web/default.yaml
@@ -33,4 +33,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/basic-api-call-es5.yaml
+++ b/samples/word/01-basics/basic-api-call-es5.yaml
@@ -89,4 +89,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/basic-api-call.yaml
+++ b/samples/word/01-basics/basic-api-call.yaml
@@ -90,4 +90,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/basic-common-api-call.yaml
+++ b/samples/word/01-basics/basic-common-api-call.yaml
@@ -44,4 +44,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/basic-doc-assembly.yaml
+++ b/samples/word/01-basics/basic-doc-assembly.yaml
@@ -216,4 +216,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/insert-and-get-pictures.yaml
+++ b/samples/word/01-basics/insert-and-get-pictures.yaml
@@ -159,4 +159,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/insert-formatted-text.yaml
+++ b/samples/word/01-basics/insert-formatted-text.yaml
@@ -108,4 +108,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/insert-header.yaml
+++ b/samples/word/01-basics/insert-header.yaml
@@ -86,4 +86,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/insert-line-and-page-breaks.yaml
+++ b/samples/word/01-basics/insert-line-and-page-breaks.yaml
@@ -149,4 +149,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/01-basics/search.yaml
+++ b/samples/word/01-basics/search.yaml
@@ -163,4 +163,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/02-paragraphs/get-paragraph-on-insertion-point.yaml
+++ b/samples/word/02-paragraphs/get-paragraph-on-insertion-point.yaml
@@ -164,4 +164,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/02-paragraphs/insert-in-different-locations.yaml
+++ b/samples/word/02-paragraphs/insert-in-different-locations.yaml
@@ -201,4 +201,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/02-paragraphs/paragraph-properties.yaml
+++ b/samples/word/02-paragraphs/paragraph-properties.yaml
@@ -178,4 +178,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/03-content-controls/insert-and-change-content-controls.yaml
+++ b/samples/word/03-content-controls/insert-and-change-content-controls.yaml
@@ -189,4 +189,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/04-range/scroll-to-range.yaml
+++ b/samples/word/04-range/scroll-to-range.yaml
@@ -150,4 +150,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/04-range/split-words-of-first-paragraph.yaml
+++ b/samples/word/04-range/split-words-of-first-paragraph.yaml
@@ -102,4 +102,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/05-tables/table-cell-access.yaml
+++ b/samples/word/05-tables/table-cell-access.yaml
@@ -134,4 +134,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/06-lists/insert-list.yaml
+++ b/samples/word/06-lists/insert-list.yaml
@@ -146,4 +146,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/07-custom-properties/get-built-in-properties.yaml
+++ b/samples/word/07-custom-properties/get-built-in-properties.yaml
@@ -87,4 +87,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/07-custom-properties/read-write-custom-document-properties.yaml
+++ b/samples/word/07-custom-properties/read-write-custom-document-properties.yaml
@@ -142,4 +142,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/50-common-patterns/multiple-property-set.yaml
+++ b/samples/word/50-common-patterns/multiple-property-set.yaml
@@ -117,4 +117,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/99-fabric/fabric-insert-form-data.yaml
+++ b/samples/word/99-fabric/fabric-insert-form-data.yaml
@@ -206,4 +206,4 @@ libraries: |-
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1

--- a/samples/word/default.yaml
+++ b/samples/word/default.yaml
@@ -53,4 +53,4 @@ libraries: |
     @microsoft/office-js-helpers@0.7.4/dist/office.helpers.d.ts
 
     jquery@3.1.1
-    @types/jquery
+    @types/jquery@3.1.1


### PR DESCRIPTION
This is a short-term fix for [script-lab-react](https://github.com/OfficeDev/script-lab-react), and a fix for [script-lab](https://github.com/OfficeDev/script-lab).

This issue, documented [here](https://github.com/OfficeDev/script-lab-react/issues/170), stems from jQuery changing its types to be split out into multiple files instead of just one `index.d.ts` file. Script Lab currently assumes all types will be in the `index.d.ts` file and does not properly handle triple slash references.

![image](https://user-images.githubusercontent.com/35939126/47399238-63cff880-d6ec-11e8-9e43-679439ea4466.png)

This change sets all samples to explicitly request `@types/jQuery@3.1.1` instead of leaving the version blank and defaulting to the latest version in which these breaking changes for Script Lab occur.