### PR TITLE
[excel] (Areas, SpecialCells) Clarifying scope of areas snippet to include special cells

### DIFF
--- a/playlists/excel.yaml
+++ b/playlists/excel.yaml
@@ -648,11 +648,12 @@
   api_set:
     ExcelApi: 1.9
 - id: excel-range-areas
-  name: RangeAreas (discontiguous ranges)
+  name: Discontiguous ranges (RangeAreas) and special cells
   fileName: range-areas.yaml
   description: >-
     Creates and uses RangeAreas, which are sets of ranges that need not be
-    contiguous.
+    contiguous, through user selection and programmatically getting sets of
+    special cells.
   rawUrl: >-
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/85-preview-apis/range-areas.yaml
   group: Preview APIs
@@ -676,15 +677,6 @@
   group: Preview APIs
   api_set:
     ExcelApi: 1.8
-- id: excel-range-remove-duplicates
-  name: Remove duplicates
-  fileName: range-remove-duplicates.yaml
-  description: Removes duplicate entries from a range.
-  rawUrl: >-
-    https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/85-preview-apis/range-remove-duplicates.yaml
-  group: Preview APIs
-  api_set:
-    ExcelAPI: 1.9
 - id: excel-scenarios-report-generation
   name: Report generation
   fileName: report-generation.yaml

--- a/samples/excel/85-preview-apis/range-areas.yaml
+++ b/samples/excel/85-preview-apis/range-areas.yaml
@@ -1,7 +1,7 @@
 order: 3
 id: excel-range-areas
-name: RangeAreas (discontiguous ranges)
-description: 'Creates and uses RangeAreas, which are sets of ranges that need not be contiguous.'
+name: Discontiguous ranges (RangeAreas) and special cells
+description: 'Creates and uses RangeAreas, which are sets of ranges that need not be contiguous, through user selection and programmatically getting sets of special cells.'
 host: EXCEL
 api_set:
     ExcelApi: 1.9
@@ -126,7 +126,7 @@ script:
 template:
     content: |
         <section class="ms-font-m">
-            <p>This sample shows how to apply actions simultaneously to multiple ranges that may not be contiguous.</p>
+            <p>This sample shows how to apply actions simultaneously to multiple, discontiguous ranges. Some of these ranges are found using the Range object's getSpecialCells method.</p>
         </section>
 
         <section class="samples ms-font-m">

--- a/samples/excel/85-preview-apis/range-areas.yaml
+++ b/samples/excel/85-preview-apis/range-areas.yaml
@@ -1,7 +1,7 @@
 order: 3
 id: excel-range-areas
 name: Discontiguous ranges (RangeAreas) and special cells
-description: 'Creates and uses RangeAreas, which are sets of ranges that need not be contiguous, through user selection and programmatically getting sets of special cells.'
+description: 'Creates and uses RangeAreas, which are sets of ranges that need not be contiguous, through user selection and programmatic selection of special cells.'
 host: EXCEL
 api_set:
     ExcelApi: 1.9

--- a/view/excel.json
+++ b/view/excel.json
@@ -73,7 +73,6 @@
   "excel-range-areas": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/85-preview-apis/range-areas.yaml",
   "excel-range-remove-duplicates": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/85-preview-apis/range-remove-duplicates.yaml",
   "excel-just-for-fun-tetrominos": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/85-preview-apis/tetrominos.yaml",
-  "excel-range-remove-duplicates": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/85-preview-apis/range-remove-duplicates.yaml",
   "excel-scenarios-report-generation": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/90-scenarios/report-generation.yaml",
   "excel-scenarios-multiple-property-set": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/90-scenarios/multiple-property-set.yaml",
   "excel-scenarios-working-with-dates": "https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/90-scenarios/working-with-dates.yaml",


### PR DESCRIPTION
This PR expands the description of the aforementioned snippet to specify the usage of special cells. This is to improve discoverability.

Note: I believe the remove duplicates stuff is a syncing relic. The change here is removing a duplicate entry for that snippet (the irony...)