### PR TITLE
[excel] (Shapes) Match geometric shape add method to new signature

### DIFF
--- a/samples/excel/85-preview-apis/shape-create-and-delete.yaml
+++ b/samples/excel/85-preview-apis/shape-create-and-delete.yaml
@@ -16,7 +16,11 @@ script:
         async function createHexagon() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Shapes");
-                const shape = sheet.shapes.addGeometricShape(Excel.GeometricShapeType.hexagon, 5, 5, 225, 200);
+                const shape = sheet.shapes.addGeometricShape(Excel.GeometricShapeType.hexagon);
+                shape.left = 5;
+                shape.top = 5;
+                shape.height = 175;
+                shape.width = 200;
                 await context.sync();
             });
         }
@@ -24,8 +28,12 @@ script:
         async function createTriangle() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Shapes");
-                const shape = sheet.shapes.addGeometricShape(Excel.GeometricShapeType.triangle, 100, 300, 150, 200);
-                shape.rotation = 45
+                const shape = sheet.shapes.addGeometricShape(Excel.GeometricShapeType.triangle);
+                shape.left = 100;
+                shape.top = 300;
+                shape.height = 150;
+                shape.width = 200;
+                shape.rotation = 45;
                 shape.fill.clear();
                 await context.sync();
             });
@@ -34,8 +42,12 @@ script:
         async function createSmileyFace() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Shapes");
-                const shape = sheet.shapes.addGeometricShape(Excel.GeometricShapeType.smileyFace, 300, 100, 100, 100);
-                shape.fill.foreColor = "yellow";
+                const shape = sheet.shapes.addGeometricShape(Excel.GeometricShapeType.smileyFace);
+                shape.left = 300;
+                shape.top = 100;
+                shape.height = 100;
+                shape.width = 100;
+                shape.fill.foreColor = "yellow"
                 await context.sync();
             });
         }

--- a/samples/excel/85-preview-apis/shape-move-and-order.yaml
+++ b/samples/excel/85-preview-apis/shape-move-and-order.yaml
@@ -73,15 +73,30 @@ script:
         async function createShapes() {
             await Excel.run(async (context) => {
                 const shapes = context.workbook.worksheets.getItem("Shapes").shapes;
-                const rectangle = shapes.addGeometricShape(Excel.GeometricShapeType.rectangle, 100, 100, 150, 150);
+                const rectangle = shapes.addGeometricShape(Excel.GeometricShapeType.rectangle);
+                rectangle.left = 100;
+                rectangle.top = 100;
+                rectangle.height = 150;
+                rectangle.width = 150;
                 rectangle.name = "Square";
                 rectangle.fill.setSolidColor("green");
-                const pentagon = shapes.addGeometricShape(Excel.GeometricShapeType.pentagon, 125, 125, 100, 100);
+
+                const pentagon = shapes.addGeometricShape(Excel.GeometricShapeType.pentagon);
+                pentagon.left = 125;
+                pentagon.top = 125;
+                pentagon.height = 100;
+                pentagon.width = 100;
                 pentagon.name = "Pentagon";
                 pentagon.fill.setSolidColor("purple");
-                const octagon = shapes.addGeometricShape(Excel.GeometricShapeType.octagon, 150, 150, 50, 50);
+
+                const octagon = shapes.addGeometricShape(Excel.GeometricShapeType.octagon);
+                octagon.left = 150;
+                octagon.top = 150;
+                octagon.height = 50;
+                octagon.width = 50;
                 octagon.name = "Octagon";
                 octagon.fill.setSolidColor("red");
+                
                 await context.sync();
             });
         }

--- a/samples/excel/85-preview-apis/tetrominos.yaml
+++ b/samples/excel/85-preview-apis/tetrominos.yaml
@@ -16,7 +16,6 @@ script:
         $("#selectedFile").change(() => tryCatch(readImageFromFile));
         $("#focusButton").click(() => tryCatch(focus));
 
-
         let backgroundPicture = getDefaultBackgroundPicture();
 
         function readImageFromFile() {
@@ -328,13 +327,11 @@ script:
                                         delete cachedShapesByPosition[key];
                                     } else {
                                         shapeCreated += 1;
-                                        const newshp = shapes.addGeometricShape(
-                                            "Rectangle",
-                                            left,
-                                            top,
-                                            BLOCK_WIDTH,
-                                            BLOCK_HEIGHT
-                                        );
+                                        const newshp = shapes.addGeometricShape("Rectangle");
+                                        newshp.left = left;
+                                        newshp.top = top;
+                                        newshp.width = BLOCK_WIDTH;
+                                        newshp.height = BLOCK_HEIGHT;
                                         validShapes[key] = newshp;
                                     }
 
@@ -513,8 +510,12 @@ script:
                                 let left = j * BLOCK_WIDTH;
                                 let key = top + "-" + left;
 
-                                let newshp = shapes.addGeometricShape("Rectangle", left, top, BLOCK_WIDTH, BLOCK_HEIGHT);
-
+                                let newshp = shapes.addGeometricShape("Rectangle");
+                                newshp.left = left;
+                                newshp.top = top;
+                                newshp.width = BLOCK_WIDTH;
+                                newshp.height = BLOCK_HEIGHT;
+                                
                                 newshp.fill.transparency = 1;
                                 newshp.fill.foreColor = "#000000";
 


### PR DESCRIPTION
`addGeomtricShape` no longer takes position and size parameters. Adjusting the snippets accordingly.

Note: There's a bug in the API at the moment around `ShapeFill.foreColor`. That's separate from this issue.