### PR TITLE
Fix #65 and update snippets accordingly

### DIFF
--- a/config/build.ts
+++ b/config/build.ts
@@ -270,7 +270,6 @@ async function processSnippets(processedSnippets: Dictionary<SnippetProcessedDat
 
         let snippetOfficeReferenceIsOk =
             officeJsReferences[0] === canonicalOfficeJsReference ||
-            host.toUpperCase() === 'OUTLOOK' /* for now, outlook does not want to use cannonical Office.js due to bug #65. */ ||
             (group.indexOf('preview-apis') >= 0 && officeJsReferences[0] === betaOfficeJsReference);
 
         if (!snippetOfficeReferenceIsOk) {

--- a/samples/outlook/01-compose-basics/get-item-subject.yaml
+++ b/samples/outlook/01-compose-basics/get-item-subject.yaml
@@ -30,7 +30,7 @@ style:
         /* Your style goes here */
     language: css
 libraries: |
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
     @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css

--- a/samples/outlook/01-compose-basics/get-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/get-selected-text.yaml
@@ -30,7 +30,7 @@ style:
         /* Your style goes here */
     language: css
 libraries: |
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
     @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css

--- a/samples/outlook/01-compose-basics/set-selected-text.yaml
+++ b/samples/outlook/01-compose-basics/set-selected-text.yaml
@@ -28,7 +28,7 @@ style:
         /* Your style goes here */
     language: css
 libraries: |
-    https://unpkg.com/@microsoft/office-js@1.1.1-private.1/dist/office.js
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
     @types/office-js
 
     office-ui-fabric-js@1.4.0/dist/css/fabric.min.css

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,10 +808,10 @@ libxmljs@~0.18.0:
     nan "~2.5.0"
     node-pre-gyp "~0.6.32"
 
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
+lodash@4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@^4.17.4:
   version "4.17.4"


### PR DESCRIPTION
The most up-to-date version of office.js no longer contains the bug we were working around, so outlook can start using cannonical js again. This also broke modern script-lab for outlook, so wins on 2 fronts.