### PR TITLE
[Word] (search) fix search snippet to load the correct properties

### DIFF
--- a/samples/word/10-content-controls/insert-and-change-content-controls.yaml
+++ b/samples/word/10-content-controls/insert-and-change-content-controls.yaml
@@ -41,8 +41,8 @@ script:
             // Gets the complete sentence (as range) associated with the insertion point.
             let evenContentControls = context.document.contentControls.getByTag("even");
             let oddContentControls = context.document.contentControls.getByTag("odd");
-            evenContentControls.load("color,title,appearance");
-            oddContentControls.load("color,title,appearance");
+            evenContentControls.load("length");
+            oddContentControls.load("length");
 
             await context.sync();
 

--- a/samples/word/25-paragraph/search.yaml
+++ b/samples/word/25-paragraph/search.yaml
@@ -15,7 +15,7 @@ script:
         async function basicSearch() {
           await Word.run(async (context) => {
             let results = context.document.body.search("Online");
-            results.load("font/highlightColor");
+            results.load("length");
 
             await context.sync();
 
@@ -33,7 +33,7 @@ script:
             // Check out how wildcard expression are built, also use the second parameter of the search method to include search modes
             // (i.e. use wildcards).
             let results = context.document.body.search("$*.[0-9][0-9]", { matchWildcards: true });
-            results.load("font/highlightColor, font/color");
+            results.load("length");
 
             await context.sync();
 
@@ -60,6 +60,8 @@ script:
                 "To make your document look professionally produced, Word provides header, footer, cover page, and text box designs that complement each other. For example, you can add a matching Online cover page, header, and sidebar. Click Insert and then choose the Online elements you want from the different Online galleries.",
                 "Replace"
               );
+
+              await context.sync();
           });
         }
 

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -2992,7 +2992,7 @@ Word.Body.search:
   - |-
     await Word.run(async (context) => {
       let results = context.document.body.search("Online");
-      results.load("font/highlightColor");
+      results.load("length");
 
       await context.sync();
 
@@ -3008,7 +3008,7 @@ Word.Body.search:
       // Check out how wildcard expression are built, also use the second parameter of the search method to include search modes
       // (i.e. use wildcards).
       let results = context.document.body.search("$*.[0-9][0-9]", { matchWildcards: true });
-      results.load("font/highlightColor, font/color");
+      results.load("length");
 
       await context.sync();
 

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -3251,8 +3251,8 @@ Word.ContentControl.set:
       // Gets the complete sentence (as range) associated with the insertion point.
       let evenContentControls = context.document.contentControls.getByTag("even");
       let oddContentControls = context.document.contentControls.getByTag("odd");
-      evenContentControls.load("color,title,appearance");
-      oddContentControls.load("color,title,appearance");
+      evenContentControls.load("length");
+      oddContentControls.load("length");
 
       await context.sync();
 


### PR DESCRIPTION
Need to load only properties that the code will be **reading**, not those that it will be writing. These snippets read `length` in loops, but they don't read any other properties. The snippets worked before only because if you load _anything_ on a collection type, you get `length` loaded too. 