### PR TITLE
excel] (Just for fun) Fixing fun snippets to use proper null checking pattern when creating worksheets

### DIFF
--- a/samples/excel/99-just-for-fun/path-finder-game.yaml
+++ b/samples/excel/99-just-for-fun/path-finder-game.yaml
@@ -44,10 +44,7 @@ script:
 
         function setupHelper(matrix: string[][]) {
             tryCatch(() => Excel.run(async (context) => {
-                if (context.workbook.worksheets.getItem("Path Finder")) {
-                    context.workbook.worksheets.getItem("Path Finder").delete();
-                }
-
+                context.workbook.worksheets.getItemOrNullObject("Path Finder").delete();
                 const sheet = context.workbook.worksheets.add("Path Finder");
 
                 sheet.getRange().format.set({

--- a/samples/excel/99-just-for-fun/patterns.yaml
+++ b/samples/excel/99-just-for-fun/patterns.yaml
@@ -14,10 +14,7 @@ script:
 
         async function drawSquares() {
             await Excel.run(async (context) => {
-                if (context.workbook.worksheets.getItem("Patterns")) {
-                    context.workbook.worksheets.getItem("Patterns").delete();
-                }
-
+                context.workbook.worksheets.getItemOrNullObject("Patterns").delete();
                 const sheet = context.workbook.worksheets.add("Patterns");
 
                 sheet.activate();
@@ -42,10 +39,7 @@ script:
 
         async function drawSpiral() {
             await Excel.run(async (context) => {
-                if (context.workbook.worksheets.getItem("Patterns")) {
-                    context.workbook.worksheets.getItem("Patterns").delete();
-                }
-
+                context.workbook.worksheets.getItemOrNullObject("Patterns").delete();
                 const sheet = context.workbook.worksheets.add("Patterns");
 
                 sheet.activate();
@@ -106,10 +100,7 @@ script:
 
         async function drawDecoration() {
             await Excel.run(async (context) => {
-                if (context.workbook.worksheets.getItem("Patterns")) {
-                    context.workbook.worksheets.getItem("Patterns").delete();
-                }
-                
+                context.workbook.worksheets.getItemOrNullObject("Patterns").delete();
                 const sheet = context.workbook.worksheets.add("Patterns");
 
                 sheet.activate();


### PR DESCRIPTION
Some worksheet creation methods within the snippets were not properly changed during the recent removal of office-js-helpers. This corrects that mistake.