### PR TITLE
[all] (Requirement Sets) Using a string to represent the requirement set in all snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A collection of code snippets built with [Script Lab](//github.com/OfficeDev/scr
 
     ```yaml
     api_set:
-        ExcelApi: 1.5
+        ExcelApi: '1.5'
     ```
 
 5. Check the name and description property values, also near the top of the file, and edit as needed.

--- a/playlists/excel.yaml
+++ b/playlists/excel.yaml
@@ -6,7 +6,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/01-basics/basic-api-call.yaml
   group: Basics
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-basics-basic-api-call-es5
   name: Basic API call (JavaScript)
   fileName: basic-api-call-es5.yaml
@@ -15,7 +15,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/01-basics/basic-api-call-es5.yaml
   group: Basics
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-basics-basic-common-api-call
   name: Basic API call (Office 2013)
   fileName: basic-common-api-call.yaml
@@ -35,7 +35,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-axis.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-axis-formatting
   name: Axis formatting
   fileName: chart-axis-formatting.yaml
@@ -44,7 +44,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-axis-formatting.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 - id: excel-chart-create-several-charts
   name: Create charts
   fileName: chart-create-several-charts.yaml
@@ -55,7 +55,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-create-several-charts.yaml
   group: Chart
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-chart-create-doughnut-chart
   name: Doughnut chart
   fileName: create-doughnut-chart.yaml
@@ -64,7 +64,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/create-doughnut-chart.yaml
   group: Chart
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-formatting
   name: Formatting
   fileName: chart-formatting.yaml
@@ -73,7 +73,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-formatting.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 - id: excel-chart-legend
   name: Legend
   fileName: chart-legend.yaml
@@ -82,7 +82,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-legend.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-point
   name: Points
   fileName: chart-point.yaml
@@ -91,7 +91,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-point.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-series
   name: Series
   fileName: chart-series.yaml
@@ -100,7 +100,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-series.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-series-markers
   name: Series markers
   fileName: chart-series-markers.yaml
@@ -109,7 +109,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-series-markers.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-series-plotorder
   name: Series plot order
   fileName: chart-series-plotorder.yaml
@@ -118,7 +118,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-series-plotorder.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-title-format
   name: Title format
   fileName: chart-title-format.yaml
@@ -127,7 +127,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-title-format.yaml
   group: Chart
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-chart-trendlines
   name: Trendlines
   fileName: chart-trendlines.yaml
@@ -136,7 +136,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/10-chart/chart-trendlines.yaml
   group: Chart
   api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 - id: excel-range-conditional-formatting-basic
   name: Basic conditional formatting
   fileName: conditional-formatting-basic.yaml
@@ -145,7 +145,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/14-conditional-formatting/conditional-formatting-basic.yaml
   group: Conditional Formatting
   api_set:
-    ExcelApi: 1.6
+    ExcelApi: '1.6'
 - id: excel-range-conditional-formatting-advanced
   name: Advanced conditional formatting
   fileName: conditional-formatting-advanced.yaml
@@ -154,7 +154,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/14-conditional-formatting/conditional-formatting-advanced.yaml
   group: Conditional Formatting
   api_set:
-    ExcelApi: 1.6
+    ExcelApi: '1.6'
 - id: excel-custom-functions-basic
   name: Basic custom function
   fileName: basic-function.yaml
@@ -190,7 +190,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/18-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
   group: Custom XML Parts
   api_set:
-    ExcelApi: 1.5
+    ExcelApi: '1.5'
 - id: excel-custom-xml-parts-test-xml-for-unique-namespace
   name: Unique namespaces in custom XML
   fileName: test-xml-for-unique-namespace.yaml
@@ -199,7 +199,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/18-custom-xml-parts/test-xml-for-unique-namespace.yaml
   group: Custom XML Parts
   api_set:
-    ExcelApi: 1.5
+    ExcelApi: '1.5'
 - id: excel-data-validation
   name: Data validation
   fileName: data-validation.yaml
@@ -210,7 +210,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/22-data-validation/data-validation.yaml
   group: Data Validation
   api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 - id: excel-document-get-file-in-slices-async
   name: Get file using slicing
   fileName: get-file-in-slices-async.yaml
@@ -221,7 +221,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/26-document/get-file-in-slices-async.yaml
   group: Document
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-document-properties
   name: Properties
   fileName: properties.yaml
@@ -230,7 +230,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/26-document/properties.yaml
   group: Document
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-events-chartcollection-added-activated
   name: Chart collection events
   fileName: events-chartcollection-added-activated.yaml
@@ -242,7 +242,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/events-chartcollection-added-activated.yaml
   group: Events
   api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 - id: excel-events-chart-activated
   name: Chart events
   fileName: events-chart-activated.yaml
@@ -253,7 +253,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/events-chart-activated.yaml
   group: Events
   api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 - id: excel-events-data-changed
   name: Data change event
   fileName: data-changed.yaml
@@ -262,7 +262,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/data-changed.yaml
   group: Events
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-data-change-event-details
   name: Data change event details
   fileName: data-change-event-details.yaml
@@ -271,7 +271,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/data-change-event-details.yaml
   group: Events
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-events-disable-events
   name: Enable and disable events
   fileName: events-disable-events.yaml
@@ -280,7 +280,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/events-disable-events.yaml
   group: Events
   api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 - id: excel-events-table-changed
   name: Table events
   fileName: events-table-changed.yaml
@@ -289,7 +289,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/events-table-changed.yaml
   group: Events
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-events-tablecollection-changed
   name: Table collection events
   fileName: events-tablecollection-changed.yaml
@@ -298,7 +298,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/events-tablecollection-changed.yaml
   group: Events
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-events-workbook-and-worksheet-collection
   name: Workbook and worksheet collection events
   fileName: events-workbook-and-worksheet-collection.yaml
@@ -309,7 +309,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
   group: Events
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-events-worksheet
   name: Worksheet events
   fileName: events-worksheet.yaml
@@ -320,7 +320,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/30-events/events-worksheet.yaml
   group: Events
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-named-item-create-and-remove-named-item
   name: 'Create, access, and remove'
   fileName: create-and-remove-named-item.yaml
@@ -329,7 +329,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/34-named-item/create-and-remove-named-item.yaml
   group: Named Item
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-update-named-item
   name: Update
   fileName: update-named-item.yaml
@@ -338,7 +338,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/34-named-item/update-named-item.yaml
   group: Named Item
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-pivottable-calculations
   name: Calculations
   fileName: pivottable-calculations.yaml
@@ -347,7 +347,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/38-pivottable/pivottable-calculations.yaml
   group: PivotTable
   api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 - id: excel-pivottable-create-and-modify
   name: Create and modify
   fileName: pivottable-create-and-modify.yaml
@@ -356,7 +356,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/38-pivottable/pivottable-create-and-modify.yaml
   group: PivotTable
   api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 - id: excel-pivottable-filters-and-summaries
   name: Filters and summaries
   fileName: pivottable-filters-and-summaries.yaml
@@ -365,7 +365,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/38-pivottable/pivottable-filters-and-summaries.yaml
   group: PivotTable
   api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 - id: excel-range-copyfrom
   name: Copy and paste ranges
   fileName: range-copyfrom.yaml
@@ -374,7 +374,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/range-copyfrom.yaml
   group: Range
   api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 - id: excel-range-areas
   name: Discontiguous ranges (RangeAreas) and special cells
   fileName: range-areas.yaml
@@ -386,7 +386,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/range-areas.yaml
   group: Range
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-range-find
   name: Find text matches within a range
   fileName: range-find.yaml
@@ -395,7 +395,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/range-find.yaml
   group: Range
   api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 - id: excel-range-formatting
   name: Formatting
   fileName: formatting.yaml
@@ -404,7 +404,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/formatting.yaml
   group: Range
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-range-cell-properties
   name: Get and set cell properties
   fileName: cell-properties.yaml
@@ -413,7 +413,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/cell-properties.yaml
   group: Range
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-range-hyperlink
   name: Hyperlinks
   fileName: range-hyperlink.yaml
@@ -422,7 +422,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/range-hyperlink.yaml
   group: Range
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-range-insert-delete-and-clear-range
   name: 'Insert, delete, and clear'
   fileName: insert-delete-clear-range.yaml
@@ -431,7 +431,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/insert-delete-clear-range.yaml
   group: Range
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-range-range-relationships
   name: Range relationships
   fileName: range-relationships.yaml
@@ -442,7 +442,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/range-relationships.yaml
   group: Range
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-range-remove-duplicates
   name: Remove duplicates
   fileName: range-remove-duplicates.yaml
@@ -451,7 +451,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/range-remove-duplicates.yaml
   group: Range
   api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 - id: excel-range-selected-range
   name: Selected range
   fileName: selected-range.yaml
@@ -460,7 +460,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/selected-range.yaml
   group: Range
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-range-text-orientation
   name: Text orientation
   fileName: range-text-orientation.yaml
@@ -469,7 +469,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/range-text-orientation.yaml
   group: Range
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-range-used-range
   name: Used range
   fileName: used-range.yaml
@@ -480,7 +480,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/used-range.yaml
   group: Range
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-range-values-and-formulas
   name: Values and formulas
   fileName: set-get-values.yaml
@@ -489,7 +489,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/42-range/set-get-values.yaml
   group: Range
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-shape-create-and-delete
   name: Create and delete geometric shapes
   fileName: shape-create-and-delete.yaml
@@ -500,7 +500,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/44-shape/shape-create-and-delete.yaml
   group: Shape
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-shape-images
   name: Image shapes
   fileName: shape-images.yaml
@@ -509,7 +509,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/44-shape/shape-images.yaml
   group: Shape
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-shape-lines
   name: Lines
   fileName: shape-lines.yaml
@@ -518,7 +518,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/44-shape/shape-lines.yaml
   group: Shape
   api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 - id: excel-shape-move-and-order
   name: Move and order shapes
   fileName: shape-move-and-order.yaml
@@ -527,7 +527,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/44-shape/shape-move-and-order.yaml
   group: Shape
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-shape-groups
   name: Shape groups
   fileName: shape-groups.yaml
@@ -536,7 +536,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/44-shape/shape-groups.yaml
   group: Shape
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-shape-textboxes
   name: Textboxes
   fileName: shape-textboxes.yaml
@@ -545,7 +545,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/44-shape/shape-textboxes.yaml
   group: Shape
   api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 - id: excel-table-add-rows-and-columns-to-a-table
   name: Add rows and columns
   fileName: add-rows-and-columns-to-a-table.yaml
@@ -554,7 +554,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/add-rows-and-columns-to-a-table.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-convert-range-to-table
   name: Convert a range
   fileName: convert-range-to-table.yaml
@@ -563,7 +563,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/convert-range-to-table.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-create-table
   name: Create a table
   fileName: create-table.yaml
@@ -572,7 +572,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/create-table.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-filter-data
   name: Filter data
   fileName: filter-data.yaml
@@ -581,7 +581,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/filter-data.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-formatting
   name: Formatting
   fileName: formatting.yaml
@@ -590,7 +590,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/formatting.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-get-data-from-table
   name: Get data
   fileName: get-data-from-table.yaml
@@ -599,7 +599,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/get-data-from-table.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-get-visible-range-of-a-filtered-table
   name: Get visible range
   fileName: get-visible-range-of-a-filtered-table.yaml
@@ -608,7 +608,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/get-visible-range-of-a-filtered-table.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-import-json-data
   name: Import JSON data
   fileName: import-json-data.yaml
@@ -617,7 +617,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/import-json-data.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-sort-data
   name: Sort data
   fileName: sort-data.yaml
@@ -626,7 +626,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/sort-data.yaml
   group: Table
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-table-style
   name: Style
   fileName: style.yaml
@@ -637,7 +637,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/46-table/style.yaml
   group: Table
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-workbook-get-active-cell
   name: Active cell
   fileName: workbook-get-active-cell.yaml
@@ -646,7 +646,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/50-workbook/workbook-get-active-cell.yaml
   group: Workbook
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-settings-create-get-change-delete-settings
   name: Add-in settings
   fileName: create-get-change-delete-settings.yaml
@@ -657,7 +657,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/50-workbook/create-get-change-delete-settings.yaml
   group: Workbook
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-workbook-create-workbook
   name: Create workbook
   fileName: create-workbook.yaml
@@ -668,7 +668,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/50-workbook/create-workbook.yaml
   group: Workbook
   api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 - id: excel-workbook-data-protection
   name: Data protection
   fileName: data-protection.yaml
@@ -677,7 +677,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/50-workbook/data-protection.yaml
   group: Workbook
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-worksheet-active-worksheet
   name: Active worksheet
   fileName: active-worksheet.yaml
@@ -686,7 +686,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/active-worksheet.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-worksheet-add-delete-rename-move-worksheet
   name: 'Add, delete, rename, and move worksheet'
   fileName: add-delete-rename-move-worksheet.yaml
@@ -695,7 +695,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/add-delete-rename-move-worksheet.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-worksheet-auto-filter
   name: AutoFilter
   fileName: worksheet-auto-filter.yaml
@@ -704,7 +704,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/worksheet-auto-filter.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-worksheet-copy
   name: Copy worksheet
   fileName: worksheet-copy.yaml
@@ -713,7 +713,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/worksheet-copy.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-worksheet-find-all
   name: Find text matches within a worksheet
   fileName: worksheet-find-all.yaml
@@ -722,7 +722,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/worksheet-find-all.yaml
   group: Worksheet
   api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 - id: excel-worksheet-freeze-panes
   name: Frozen panes
   fileName: worksheet-freeze-panes.yaml
@@ -733,7 +733,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/worksheet-freeze-panes.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-worksheet-worksheet-range-cell
   name: Get range or cell
   fileName: worksheet-range-cell.yaml
@@ -744,7 +744,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/worksheet-range-cell.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-worksheet-gridlines
   name: Gridlines
   fileName: gridlines.yaml
@@ -753,7 +753,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/gridlines.yaml
   group: Worksheet
   api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 - id: excel-worksheet-list-worksheets
   name: List worksheets
   fileName: list-worksheets.yaml
@@ -762,7 +762,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/list-worksheets.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-worksheet-page-layout
   name: Page layout and print settings
   fileName: worksheet-page-layout.yaml
@@ -771,7 +771,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/worksheet-page-layout.yaml
   group: Worksheet
   api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 - id: excel-worksheet-reference-worksheets-by-relative-position
   name: Reference worksheets by relative position
   fileName: reference-worksheets-by-relative-position.yaml
@@ -780,7 +780,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/reference-worksheets-by-relative-position.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.5
+    ExcelApi: '1.5'
 - id: excel-worksheet-tab-color
   name: Tab color
   fileName: tab-color.yaml
@@ -789,7 +789,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/tab-color.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 - id: excel-worksheet-visibility
   name: Visibility
   fileName: worksheet-visibility.yaml
@@ -798,7 +798,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/54-worksheet/worksheet-visibility.yaml
   group: Worksheet
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-comment
   name: Comments
   fileName: comment.yaml
@@ -854,7 +854,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/90-scenarios/performance-optimization.yaml
   group: Scenarios
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-scenarios-report-generation
   name: Report generation
   fileName: report-generation.yaml
@@ -865,7 +865,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/90-scenarios/report-generation.yaml
   group: Scenarios
   api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 - id: excel-scenarios-multiple-property-set
   name: Set multiple properties
   fileName: multiple-property-set.yaml
@@ -874,7 +874,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/90-scenarios/multiple-property-set.yaml
   group: Scenarios
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-scenarios-working-with-dates
   name: Working with dates
   fileName: working-with-dates.yaml
@@ -885,7 +885,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/90-scenarios/working-with-dates.yaml
   group: Scenarios
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-just-for-fun-patterns
   name: Colorful Patterns
   fileName: patterns.yaml
@@ -896,7 +896,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/99-just-for-fun/patterns.yaml
   group: Just For Fun
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-just-for-fun-gradient
   name: Gradient
   fileName: gradient.yaml
@@ -907,7 +907,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/99-just-for-fun/gradient.yaml
   group: Just For Fun
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-just-for-fun-path-finder-game
   name: Path finder
   fileName: path-finder-game.yaml
@@ -918,7 +918,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/99-just-for-fun/path-finder-game.yaml
   group: Just For Fun
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 - id: excel-just-for-fun-tetrominos
   name: Tetromino stacking
   fileName: tetrominos.yaml
@@ -927,7 +927,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/99-just-for-fun/tetrominos.yaml
   group: Just For Fun
   api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 - id: excel-just-for-fun-color-wheel
   name: Wheel of colors
   fileName: color-wheel.yaml
@@ -938,4 +938,4 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/excel/99-just-for-fun/color-wheel.yaml
   group: Just For Fun
   api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'

--- a/playlists/word.yaml
+++ b/playlists/word.yaml
@@ -6,7 +6,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/01-basics/basic-api-call.yaml
   group: Basics
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-basics-api-call-es5
   name: Basic API call (JavaScript)
   fileName: basic-api-call-es5.yaml
@@ -15,7 +15,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/01-basics/basic-api-call-es5.yaml
   group: Basics
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-basics-basic-common-api-call
   name: Basic API call (Office 2013)
   fileName: basic-common-api-call.yaml
@@ -35,7 +35,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/10-content-controls/insert-and-change-content-controls.yaml
   group: Content Controls
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-images-insert-and-get-pictures
   name: Use inline pictures
   fileName: insert-and-get-pictures.yaml
@@ -44,7 +44,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/15-images/insert-and-get-pictures.yaml
   group: Images
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-lists-insert-list
   name: Create a list
   fileName: insert-list.yaml
@@ -53,7 +53,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/20-lists/insert-list.yaml
   group: Lists
   api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 - id: word-paragraph-get-paragraph-on-insertion-point
   name: Get paragraph from insertion point
   fileName: get-paragraph-on-insertion-point.yaml
@@ -62,7 +62,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/get-paragraph-on-insertion-point.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-paragraph-insert-line-and-page-breaks
   name: Insert breaks
   fileName: insert-line-and-page-breaks.yaml
@@ -71,7 +71,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/insert-line-and-page-breaks.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 - id: word-paragraph-insert-in-different-locations
   name: Insert content at different locations
   fileName: insert-in-different-locations.yaml
@@ -80,7 +80,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/insert-in-different-locations.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 - id: word-paragraph-insert-formatted-text
   name: Insert formatted text
   fileName: insert-formatted-text.yaml
@@ -89,7 +89,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/insert-formatted-text.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-paragraph-insert-header-and-footer
   name: Insert a header and footer
   fileName: insert-header-and-footer.yaml
@@ -98,7 +98,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/insert-header-and-footer.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-paragraph-paragraph-properties
   name: Paragraph properties
   fileName: paragraph-properties.yaml
@@ -107,7 +107,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/paragraph-properties.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 - id: word-paragraph-search
   name: Search
   fileName: search.yaml
@@ -116,7 +116,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/search.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-paragraph-get-word-count
   name: Get word count
   fileName: get-word-count.yaml
@@ -125,7 +125,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/25-paragraph/get-word-count.yaml
   group: Paragraph
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-properties-get-built-in-properties
   name: Built-in document properties
   fileName: get-built-in-properties.yaml
@@ -134,7 +134,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/30-properties/get-built-in-properties.yaml
   group: Properties
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-properties-read-write-custom-document-properties
   name: Custom document properties
   fileName: read-write-custom-document-properties.yaml
@@ -143,7 +143,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/30-properties/read-write-custom-document-properties.yaml
   group: Properties
   api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 - id: word-ranges-scroll-to-range
   name: Scroll to a range
   fileName: scroll-to-range.yaml
@@ -152,7 +152,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/35-ranges/scroll-to-range.yaml
   group: Ranges
   api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 - id: word-ranges-split-words-of-first-paragraph
   name: Split a paragraph into ranges
   fileName: split-words-of-first-paragraph.yaml
@@ -163,7 +163,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/35-ranges/split-words-of-first-paragraph.yaml
   group: Ranges
   api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 - id: word-tables-table-cell-access
   name: Create and access a table
   fileName: table-cell-access.yaml
@@ -172,7 +172,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/40-tables/table-cell-access.yaml
   group: Tables
   api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 - id: word-scenarios-doc-assembly
   name: Document assembly
   fileName: doc-assembly.yaml
@@ -181,7 +181,7 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/90-scenarios/doc-assembly.yaml
   group: Scenarios
   api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 - id: word-scenarios-multiple-property-set
   name: Set multiple properties at once
   fileName: multiple-property-set.yaml
@@ -190,4 +190,4 @@
     https://raw.githubusercontent.com/<ACCOUNT>/<REPO>/<BRANCH>/samples/word/90-scenarios/multiple-property-set.yaml
   group: Scenarios
   api_set:
-    WordApi: 1.3
+    WordApi: '1.3'

--- a/samples/excel/01-basics/basic-api-call-es5.yaml
+++ b/samples/excel/01-basics/basic-api-call-es5.yaml
@@ -5,7 +5,7 @@ description: Performs a basic Excel API call using plain JavaScript & Promises.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#run").click(() => tryCatch(run));

--- a/samples/excel/01-basics/basic-api-call.yaml
+++ b/samples/excel/01-basics/basic-api-call.yaml
@@ -5,7 +5,7 @@ description: Performs a basic Excel API call using TypeScript.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#run").click(() => tryCatch(run));

--- a/samples/excel/10-chart/chart-axis-formatting.yaml
+++ b/samples/excel/10-chart/chart-axis-formatting.yaml
@@ -4,7 +4,7 @@ name: Axis formatting
 description: Formats the vertical and horizontal axes in a chart.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-axis.yaml
+++ b/samples/excel/10-chart/chart-axis.yaml
@@ -4,7 +4,7 @@ name: Axis details
 description: 'Gets, sets, and removes axis unit, label, and title in a chart.'
 host: EXCEL
 api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-create-several-charts.yaml
+++ b/samples/excel/10-chart/chart-create-several-charts.yaml
@@ -5,7 +5,7 @@ description: 'Creates column-clustered, line, XY-scatter, area, radar, pie, 3D, 
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-formatting.yaml
+++ b/samples/excel/10-chart/chart-formatting.yaml
@@ -4,7 +4,7 @@ name: Formatting
 description: Formats labels and lines of a slope chart.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-legend.yaml
+++ b/samples/excel/10-chart/chart-legend.yaml
@@ -4,7 +4,7 @@ name: Legend
 description: Formats the legend's font.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-point.yaml
+++ b/samples/excel/10-chart/chart-point.yaml
@@ -4,7 +4,7 @@ name: Points
 description: Sets the color of a point on the chart.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 script:
     content: |+
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-series-markers.yaml
+++ b/samples/excel/10-chart/chart-series-markers.yaml
@@ -4,7 +4,7 @@ name: Series markers
 description: Sets the chart series marker properties.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-series-plotorder.yaml
+++ b/samples/excel/10-chart/chart-series-plotorder.yaml
@@ -4,7 +4,7 @@ name: Series plot order
 description: Orders the plotting of series in a chart.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-series.yaml
+++ b/samples/excel/10-chart/chart-series.yaml
@@ -4,7 +4,7 @@ name: Series
 description: Adds and deletes series in a chart.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-title-format.yaml
+++ b/samples/excel/10-chart/chart-title-format.yaml
@@ -4,7 +4,7 @@ name: Title format
 description: Adjust a chart title's format.
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/chart-trendlines.yaml
+++ b/samples/excel/10-chart/chart-trendlines.yaml
@@ -4,7 +4,7 @@ name: Trendlines
 description: 'Adds, gets, and formats trendlines in a chart.'
 host: EXCEL
 api_set:
-    ExcelAPI: 1.7
+    ExcelApi: '1.7'
 script:
     content: |+
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/10-chart/create-doughnut-chart.yaml
+++ b/samples/excel/10-chart/create-doughnut-chart.yaml
@@ -5,7 +5,7 @@ description: Creates a doughnut chart and adjusts its size.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/14-conditional-formatting/conditional-formatting-advanced.yaml
+++ b/samples/excel/14-conditional-formatting/conditional-formatting-advanced.yaml
@@ -4,7 +4,7 @@ name: Advanced conditional formatting
 description: Applies more than one conditional format on the same range.
 host: EXCEL
 api_set:
-    ExcelApi: 1.6
+    ExcelApi: '1.6'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/14-conditional-formatting/conditional-formatting-basic.yaml
+++ b/samples/excel/14-conditional-formatting/conditional-formatting-basic.yaml
@@ -4,7 +4,7 @@ name: Basic conditional formatting
 description: Applies common types of conditional formatting to ranges.
 host: EXCEL
 api_set:
-    ExcelApi: 1.6
+    ExcelApi: '1.6'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/18-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
+++ b/samples/excel/18-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
@@ -5,7 +5,7 @@ description: 'Creates, sets, gets, and deletes a custom XML part.'
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.5
+    ExcelApi: '1.5'
 script:
     content: |
         $("#create-custom-xml-part").click(() => tryCatch(createCustomXmlPart));

--- a/samples/excel/18-custom-xml-parts/test-xml-for-unique-namespace.yaml
+++ b/samples/excel/18-custom-xml-parts/test-xml-for-unique-namespace.yaml
@@ -5,7 +5,7 @@ description: Tests to see if there is only one XML part for a specified namespac
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.5
+    ExcelApi: '1.5'
 script:
     content: |
         $("#create-custom-xml-part").click(() => tryCatch(createCustomXmlPart));

--- a/samples/excel/22-data-validation/data-validation.yaml
+++ b/samples/excel/22-data-validation/data-validation.yaml
@@ -4,7 +4,7 @@ name: Data validation
 description: 'Sets data validation rules on ranges, prompts users to enter valid data, and displays messages when invalid data is entered.'
 host: EXCEL
 api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/26-document/get-file-in-slices-async.yaml
+++ b/samples/excel/26-document/get-file-in-slices-async.yaml
@@ -4,7 +4,7 @@ name: Get file using slicing
 description: Uses slicing to get the byte array and base64-encoded string that represent the current document.
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/26-document/properties.yaml
+++ b/samples/excel/26-document/properties.yaml
@@ -4,7 +4,7 @@ name: Properties
 description: Gets and sets document properties.
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#set-doc-properties").click(() => tryCatch(setDocProperties));

--- a/samples/excel/30-events/data-change-event-details.yaml
+++ b/samples/excel/30-events/data-change-event-details.yaml
@@ -4,7 +4,7 @@ name: Data change event details
 description: Uses the onChanged event of a table to determine the specifics of changes.
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/30-events/data-changed.yaml
+++ b/samples/excel/30-events/data-changed.yaml
@@ -5,7 +5,7 @@ description: Registers an event handler that runs when data is changed.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/30-events/events-chart-activated.yaml
+++ b/samples/excel/30-events/events-chart-activated.yaml
@@ -4,7 +4,7 @@ name: Chart events
 description: Registers event handlers on an individual chart that run when the chart is activated or deactivated.
 host: EXCEL
 api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/30-events/events-chartcollection-added-activated.yaml
+++ b/samples/excel/30-events/events-chartcollection-added-activated.yaml
@@ -4,7 +4,7 @@ name: Chart collection events
 description: 'Registers event handlers on a worksheet''s chart collection that run when any chart within is activated or deactivated, as well as when charts are added to or deleted from the collection.'
 host: EXCEL
 api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/30-events/events-disable-events.yaml
+++ b/samples/excel/30-events/events-disable-events.yaml
@@ -4,7 +4,7 @@ name: Enable and disable events
 description: Toggles event firing on and off.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 script:
     content: |
         $("#toggleEvents").click(() => tryCatch(toggleEvents));

--- a/samples/excel/30-events/events-table-changed.yaml
+++ b/samples/excel/30-events/events-table-changed.yaml
@@ -4,7 +4,7 @@ name: Table events
 description: Registers event handlers that run when a table is changed or selected.
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |+
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/30-events/events-tablecollection-changed.yaml
+++ b/samples/excel/30-events/events-tablecollection-changed.yaml
@@ -4,7 +4,7 @@ name: Table collection events
 description: Registers an event handler that runs when a table collection is changed.
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |+
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+++ b/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
@@ -5,7 +5,7 @@ description: 'Registers event handlers that run when a worksheet is added, activ
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |-
         $("#register-on-add-handler").click(() => tryCatch(registerOnAddHandler));

--- a/samples/excel/30-events/events-worksheet.yaml
+++ b/samples/excel/30-events/events-worksheet.yaml
@@ -5,7 +5,7 @@ description: 'Registers event handlers that run when data is changed in workshee
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/34-named-item/create-and-remove-named-item.yaml
+++ b/samples/excel/34-named-item/create-and-remove-named-item.yaml
@@ -4,7 +4,7 @@ name: 'Create, access, and remove'
 description: 'Creates, accesses, and removes named items in a worksheet.'
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/34-named-item/update-named-item.yaml
+++ b/samples/excel/34-named-item/update-named-item.yaml
@@ -5,7 +5,7 @@ description: Creates and then updates a named item.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |-
         $("#add-named-item").click(() => tryCatch(addNamedItem));

--- a/samples/excel/38-pivottable/pivottable-calculations.yaml
+++ b/samples/excel/38-pivottable/pivottable-calculations.yaml
@@ -5,7 +5,7 @@ description: Changes the calculations the PivotTable performs.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/38-pivottable/pivottable-create-and-modify.yaml
+++ b/samples/excel/38-pivottable/pivottable-create-and-modify.yaml
@@ -5,7 +5,7 @@ description: Creates and modifies a PivotTable.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 script:
     content: |-
         $("#deletePivot").click(() => tryCatch(deletePivot));

--- a/samples/excel/38-pivottable/pivottable-filters-and-summaries.yaml
+++ b/samples/excel/38-pivottable/pivottable-filters-and-summaries.yaml
@@ -5,7 +5,7 @@ description: Filters PivotTable data and shows different summarizations.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/cell-properties.yaml
+++ b/samples/excel/42-range/cell-properties.yaml
@@ -5,7 +5,7 @@ description: Sets different properties across a range then retrieves those prope
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#set-cell-properties").click(() => tryCatch(setCellProperties));

--- a/samples/excel/42-range/formatting.yaml
+++ b/samples/excel/42-range/formatting.yaml
@@ -5,7 +5,7 @@ description: Formats a range.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/insert-delete-clear-range.yaml
+++ b/samples/excel/42-range/insert-delete-clear-range.yaml
@@ -5,7 +5,7 @@ description: 'Inserts, deletes, and clears a range.'
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/range-areas.yaml
+++ b/samples/excel/42-range/range-areas.yaml
@@ -4,7 +4,7 @@ name: Discontiguous ranges (RangeAreas) and special cells
 description: 'Creates and uses RangeAreas, which are sets of ranges that need not be contiguous, through user selection and programmatic selection of special cells.'
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#reset").click(() => tryCatch(reset));

--- a/samples/excel/42-range/range-copyfrom.yaml
+++ b/samples/excel/42-range/range-copyfrom.yaml
@@ -4,7 +4,7 @@ name: Copy and paste ranges
 description: Copies data and formatting from one range to another.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/range-find.yaml
+++ b/samples/excel/42-range/range-find.yaml
@@ -4,7 +4,7 @@ name: Find text matches within a range
 description: Finds a cell within a range based on string matching.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/range-hyperlink.yaml
+++ b/samples/excel/42-range/range-hyperlink.yaml
@@ -5,7 +5,7 @@ description: 'Creates, updates, and clears hyperlinks in a range.'
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/range-relationships.yaml
+++ b/samples/excel/42-range/range-relationships.yaml
@@ -5,7 +5,7 @@ description: 'Shows relationships between ranges, such as bounding rectangles an
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/range-remove-duplicates.yaml
+++ b/samples/excel/42-range/range-remove-duplicates.yaml
@@ -4,7 +4,7 @@ name: Remove duplicates
 description: Removes duplicate entries from a range.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/range-text-orientation.yaml
+++ b/samples/excel/42-range/range-text-orientation.yaml
@@ -5,7 +5,7 @@ description: Gets and sets the text orientation within a range.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/selected-range.yaml
+++ b/samples/excel/42-range/selected-range.yaml
@@ -5,7 +5,7 @@ description: Gets and sets the currently selected range.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#get-selection").click(() => tryCatch(getSelection));

--- a/samples/excel/42-range/set-get-values.yaml
+++ b/samples/excel/42-range/set-get-values.yaml
@@ -5,7 +5,7 @@ description: Gets and sets values and formulas for a range.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/42-range/used-range.yaml
+++ b/samples/excel/42-range/used-range.yaml
@@ -5,7 +5,7 @@ description: Tests for a used range and creates a chart from a table only if the
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/44-shape/shape-create-and-delete.yaml
+++ b/samples/excel/44-shape/shape-create-and-delete.yaml
@@ -4,7 +4,7 @@ name: Create and delete geometric shapes
 description: Creates a few different geometric shapes and deletes them from the worksheet.
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/44-shape/shape-groups.yaml
+++ b/samples/excel/44-shape/shape-groups.yaml
@@ -4,7 +4,7 @@ name: Shape groups
 description: Groups and ungroups shapes.
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/44-shape/shape-images.yaml
+++ b/samples/excel/44-shape/shape-images.yaml
@@ -4,7 +4,7 @@ name: Image shapes
 description: Creates and adjusts image-based shapes.
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/44-shape/shape-lines.yaml
+++ b/samples/excel/44-shape/shape-lines.yaml
@@ -4,7 +4,7 @@ name: Lines
 description: Creates and modifies line shapes.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/44-shape/shape-move-and-order.yaml
+++ b/samples/excel/44-shape/shape-move-and-order.yaml
@@ -4,7 +4,7 @@ name: Move and order shapes
 description: Moves created shapes around the worksheet and adjusts their z-order.
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/44-shape/shape-textboxes.yaml
+++ b/samples/excel/44-shape/shape-textboxes.yaml
@@ -4,7 +4,7 @@ name: Textboxes
 description: Creates a textbox shape and works with the text in it and other shapes.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/46-table/add-rows-and-columns-to-a-table.yaml
+++ b/samples/excel/46-table/add-rows-and-columns-to-a-table.yaml
@@ -5,7 +5,7 @@ description: Adds rows and columns to a table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/46-table/convert-range-to-table.yaml
+++ b/samples/excel/46-table/convert-range-to-table.yaml
@@ -5,7 +5,7 @@ description: Converts a range to a table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/46-table/create-table.yaml
+++ b/samples/excel/46-table/create-table.yaml
@@ -5,7 +5,7 @@ description: Creates a table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#create-table").click(() => tryCatch(createTable));

--- a/samples/excel/46-table/filter-data.yaml
+++ b/samples/excel/46-table/filter-data.yaml
@@ -5,7 +5,7 @@ description: Filters table data.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/46-table/formatting.yaml
+++ b/samples/excel/46-table/formatting.yaml
@@ -5,7 +5,7 @@ description: Formats a table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/46-table/get-data-from-table.yaml
+++ b/samples/excel/46-table/get-data-from-table.yaml
@@ -5,7 +5,7 @@ description: Gets data from a table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/46-table/get-visible-range-of-a-filtered-table.yaml
+++ b/samples/excel/46-table/get-visible-range-of-a-filtered-table.yaml
@@ -5,7 +5,7 @@ description: Gets the visible range from a filtered table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |+
         $("#create-table").click(() => tryCatch(createTable));

--- a/samples/excel/46-table/import-json-data.yaml
+++ b/samples/excel/46-table/import-json-data.yaml
@@ -5,7 +5,7 @@ description: Imports JSON data into a table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#import-json-data").click(() => tryCatch(importJsonData));

--- a/samples/excel/46-table/sort-data.yaml
+++ b/samples/excel/46-table/sort-data.yaml
@@ -5,7 +5,7 @@ description: Sorts the data within a table.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/46-table/style.yaml
+++ b/samples/excel/46-table/style.yaml
@@ -5,7 +5,7 @@ description: 'Creates a custom style, applies a custom and built-in styles to a 
 author: siewmoi
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |+
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/50-workbook/create-get-change-delete-settings.yaml
+++ b/samples/excel/50-workbook/create-get-change-delete-settings.yaml
@@ -5,7 +5,7 @@ description: 'Creates, gets, changes, and deletes settings that are unique to th
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#create-setting").click(() => tryCatch(createSetting));

--- a/samples/excel/50-workbook/create-workbook.yaml
+++ b/samples/excel/50-workbook/create-workbook.yaml
@@ -5,7 +5,7 @@ description: 'Creates a new, empty workbook and creates a new workbook by copyin
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.8
+    ExcelApi: '1.8'
 script:
     content: |
         $("#create-new-blank-workbook").click(() => tryCatch(createBlankWorkbook));

--- a/samples/excel/50-workbook/data-protection.yaml
+++ b/samples/excel/50-workbook/data-protection.yaml
@@ -4,7 +4,7 @@ name: Data protection
 description: Protects data in a worksheet and the workbook structure.
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/50-workbook/workbook-get-active-cell.yaml
+++ b/samples/excel/50-workbook/workbook-get-active-cell.yaml
@@ -4,7 +4,7 @@ name: Active cell
 description: Gets the active cell of the entire workbook.
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#get-active-cell").click(() => tryCatch(run));

--- a/samples/excel/54-worksheet/active-worksheet.yaml
+++ b/samples/excel/54-worksheet/active-worksheet.yaml
@@ -5,7 +5,7 @@ description: Gets and sets the active worksheet.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |-
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/add-delete-rename-move-worksheet.yaml
+++ b/samples/excel/54-worksheet/add-delete-rename-move-worksheet.yaml
@@ -5,7 +5,7 @@ description: 'Adds, deletes, renames, and moves a worksheet.'
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#add-worksheet").click(() => tryCatch(addWorksheet));

--- a/samples/excel/54-worksheet/gridlines.yaml
+++ b/samples/excel/54-worksheet/gridlines.yaml
@@ -5,7 +5,7 @@ description: Hides and shows a worksheet's gridlines.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelAPI: 1.8
+    ExcelApi: '1.8'
 script:
     content: |
         $("#hide-gridlines").click(() => tryCatch(hideGridlines));

--- a/samples/excel/54-worksheet/list-worksheets.yaml
+++ b/samples/excel/54-worksheet/list-worksheets.yaml
@@ -5,7 +5,7 @@ description: Lists the worksheets in the workbook.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#list-worksheets").click(() => tryCatch(listWorksheets));

--- a/samples/excel/54-worksheet/reference-worksheets-by-relative-position.yaml
+++ b/samples/excel/54-worksheet/reference-worksheets-by-relative-position.yaml
@@ -5,7 +5,7 @@ description: Gets a worksheet by using its relative position within the workbook
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.5
+    ExcelApi: '1.5'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/tab-color.yaml
+++ b/samples/excel/54-worksheet/tab-color.yaml
@@ -5,7 +5,7 @@ description: Gets and sets the tab color of a worksheet.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#set-tab-color-to-hex-color").click(() => tryCatch(setTabColorToHexColor));

--- a/samples/excel/54-worksheet/worksheet-auto-filter.yaml
+++ b/samples/excel/54-worksheet/worksheet-auto-filter.yaml
@@ -4,7 +4,7 @@ name: AutoFilter
 description: Adds an AutoFilter to a worksheet.
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/worksheet-copy.yaml
+++ b/samples/excel/54-worksheet/worksheet-copy.yaml
@@ -4,7 +4,7 @@ name: Copy worksheet
 description: Copies the active worksheet to the specified location.
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/worksheet-find-all.yaml
+++ b/samples/excel/54-worksheet/worksheet-find-all.yaml
@@ -4,7 +4,7 @@ name: Find text matches within a worksheet
 description: Finds cells within a worksheet based on string matching.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/worksheet-freeze-panes.yaml
+++ b/samples/excel/54-worksheet/worksheet-freeze-panes.yaml
@@ -5,7 +5,7 @@ description: 'Freezes columns, rows, and a range of cells. Gets the address of t
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.7
+    ExcelApi: '1.7'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/worksheet-page-layout.yaml
+++ b/samples/excel/54-worksheet/worksheet-page-layout.yaml
@@ -4,7 +4,7 @@ name: Page layout and print settings
 description: Changes the page layout and other settings for printing a worksheet.
 host: EXCEL
 api_set:
-    ExcelAPI: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/worksheet-range-cell.yaml
+++ b/samples/excel/54-worksheet/worksheet-range-cell.yaml
@@ -5,7 +5,7 @@ description: 'Gets the used range, the entire range of a worksheet, the specifie
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/54-worksheet/worksheet-visibility.yaml
+++ b/samples/excel/54-worksheet/worksheet-visibility.yaml
@@ -5,7 +5,7 @@ description: Hides and unhides a worksheet.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#hide-worksheet").click(() => tryCatch(hideWorksheet));

--- a/samples/excel/90-scenarios/multiple-property-set.yaml
+++ b/samples/excel/90-scenarios/multiple-property-set.yaml
@@ -5,7 +5,7 @@ description: Sets multiple properties at once with the API object set() method.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/90-scenarios/performance-optimization.yaml
+++ b/samples/excel/90-scenarios/performance-optimization.yaml
@@ -4,7 +4,7 @@ name: Performance optimization
 description: Optimizes performance by untracking ranges and turning off screen painting.
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/excel/90-scenarios/report-generation.yaml
+++ b/samples/excel/90-scenarios/report-generation.yaml
@@ -5,7 +5,7 @@ description: 'Writes data to the workbook, reads and applies basic formatting, a
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#create-report").click(() => tryCatch(createReport));

--- a/samples/excel/90-scenarios/working-with-dates.yaml
+++ b/samples/excel/90-scenarios/working-with-dates.yaml
@@ -5,7 +5,7 @@ description: Shows how to work with dates by using the Moment JavaScript library
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         declare var moment: any;

--- a/samples/excel/99-just-for-fun/color-wheel.yaml
+++ b/samples/excel/99-just-for-fun/color-wheel.yaml
@@ -5,7 +5,7 @@ description: Uses chart formatting to draw a wheel with changing colors. Contrib
 author: AlexanderZlatkovski
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#wheel").click(wheelGo);

--- a/samples/excel/99-just-for-fun/gradient.yaml
+++ b/samples/excel/99-just-for-fun/gradient.yaml
@@ -5,7 +5,7 @@ description: Uses range formatting and external libraries to draw a colorful gra
 author: AlexanderZlatkovski
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |-
         initializeColorPickers();

--- a/samples/excel/99-just-for-fun/path-finder-game.yaml
+++ b/samples/excel/99-just-for-fun/path-finder-game.yaml
@@ -5,7 +5,7 @@ description: Uses range formatting to play a "pathfinder game". Contributed by A
 author: AlexanderZlatkovski
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |
         $("#setup").click(setup);

--- a/samples/excel/99-just-for-fun/patterns.yaml
+++ b/samples/excel/99-just-for-fun/patterns.yaml
@@ -5,7 +5,7 @@ description: Uses range formatting to draw interesting pattern. Contributed by A
 author: AlexanderZlatkovski
 host: EXCEL
 api_set:
-    ExcelApi: 1.4
+    ExcelApi: '1.4'
 script:
     content: |-
         $("#squares").click(() => tryCatch(drawSquares));

--- a/samples/excel/99-just-for-fun/tetrominos.yaml
+++ b/samples/excel/99-just-for-fun/tetrominos.yaml
@@ -5,7 +5,7 @@ description: Arrange moving tetromino shapes to form lines.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.9
+    ExcelApi: '1.9'
 script:
     content: |-
         $("#run").click(() => {

--- a/samples/excel/default.yaml
+++ b/samples/excel/default.yaml
@@ -4,7 +4,7 @@ description: Create a new snippet from a blank template.
 author: OfficeDev
 host: EXCEL
 api_set:
-    ExcelApi: 1.1
+    ExcelApi: '1.1'
 script:
     content: |
         $("#run").click(() => tryCatch(run));

--- a/samples/onenote/default.yaml
+++ b/samples/onenote/default.yaml
@@ -4,7 +4,7 @@ description: Create a new snippet from a blank template.
 author: OfficeDev
 host: ONENOTE
 api_set:
-    OneNoteApi: 1.1
+    OneNoteApi: '1.1'
 script:
     content: |
         $("#run").click(() => tryCatch(run));

--- a/samples/word/01-basics/basic-api-call-es5.yaml
+++ b/samples/word/01-basics/basic-api-call-es5.yaml
@@ -5,7 +5,7 @@ description: Performs a basic Word API call using plain JavaScript & Promises.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |-
         $("#run").click(() => tryCatch(run));

--- a/samples/word/01-basics/basic-api-call.yaml
+++ b/samples/word/01-basics/basic-api-call.yaml
@@ -5,7 +5,7 @@ description: Performs a basic Word API call using TypeScript.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |-
         $("#run").click(() => tryCatch(run));

--- a/samples/word/10-content-controls/insert-and-change-content-controls.yaml
+++ b/samples/word/10-content-controls/insert-and-change-content-controls.yaml
@@ -5,7 +5,7 @@ description: 'Inserts, updates, and retrieves content controls.'
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |
         $("#insert-controls").click(() => tryCatch(insertContentControls));

--- a/samples/word/15-images/insert-and-get-pictures.yaml
+++ b/samples/word/15-images/insert-and-get-pictures.yaml
@@ -5,7 +5,7 @@ description: Inserts and gets inline pictures.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/word/20-lists/insert-list.yaml
+++ b/samples/word/20-lists/insert-list.yaml
@@ -5,7 +5,7 @@ description: Inserts a new list into the document.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 script:
     content: |
         $("#insert-controls").click(() => tryCatch(insertList));

--- a/samples/word/25-paragraph/get-paragraph-on-insertion-point.yaml
+++ b/samples/word/25-paragraph/get-paragraph-on-insertion-point.yaml
@@ -5,7 +5,7 @@ description: Gets the full paragraph containing the insertion point.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |
         $("#get-paragraph").click(() => tryCatch(getParagraph));

--- a/samples/word/25-paragraph/get-word-count.yaml
+++ b/samples/word/25-paragraph/get-word-count.yaml
@@ -5,7 +5,7 @@ description: Counts how many times a word or term appears in the document.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/word/25-paragraph/insert-formatted-text.yaml
+++ b/samples/word/25-paragraph/insert-formatted-text.yaml
@@ -5,7 +5,7 @@ description: Formats text with pre-built and custom styles.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |-
         $("#add-text").click(() => tryCatch(addFormattedText));

--- a/samples/word/25-paragraph/insert-header-and-footer.yaml
+++ b/samples/word/25-paragraph/insert-header-and-footer.yaml
@@ -5,7 +5,7 @@ description: Inserts a header and a footer in the document.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |-
         $("#add-header").click(() => tryCatch(addHeader));

--- a/samples/word/25-paragraph/insert-in-different-locations.yaml
+++ b/samples/word/25-paragraph/insert-in-different-locations.yaml
@@ -5,7 +5,7 @@ description: Inserts content at different document locations.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/word/25-paragraph/insert-line-and-page-breaks.yaml
+++ b/samples/word/25-paragraph/insert-line-and-page-breaks.yaml
@@ -5,7 +5,7 @@ description: Inserts page and line breaks in a document.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/word/25-paragraph/paragraph-properties.yaml
+++ b/samples/word/25-paragraph/paragraph-properties.yaml
@@ -5,7 +5,7 @@ description: 'Sets indentation, space between paragraphs, and other paragraph pr
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 script:
     content: |
         $("#indent").click(() => tryCatch(indent));

--- a/samples/word/25-paragraph/search.yaml
+++ b/samples/word/25-paragraph/search.yaml
@@ -5,7 +5,7 @@ description: Shows basic and advanced search capabilities.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/word/30-properties/get-built-in-properties.yaml
+++ b/samples/word/30-properties/get-built-in-properties.yaml
@@ -5,7 +5,7 @@ description: Gets built-in document properties.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |-
         $("#run").click(() => tryCatch(getProperties));

--- a/samples/word/30-properties/read-write-custom-document-properties.yaml
+++ b/samples/word/30-properties/read-write-custom-document-properties.yaml
@@ -5,7 +5,7 @@ description: Adds and reads custom document properties of different types.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 script:
     content: |-
         $("#number").click(() => tryCatch(insertNumericProperty));

--- a/samples/word/35-ranges/scroll-to-range.yaml
+++ b/samples/word/35-ranges/scroll-to-range.yaml
@@ -5,7 +5,7 @@ description: Scrolls to a range with and without selection.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.2
+    WordApi: '1.2'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/word/35-ranges/split-words-of-first-paragraph.yaml
+++ b/samples/word/35-ranges/split-words-of-first-paragraph.yaml
@@ -5,7 +5,7 @@ description: 'Splits a paragraph into word ranges and then traverses all the ran
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 script:
     content: |
         $("#setup").click(() => tryCatch(setup));

--- a/samples/word/40-tables/table-cell-access.yaml
+++ b/samples/word/40-tables/table-cell-access.yaml
@@ -5,7 +5,7 @@ description: Creates a table and accesses a specific cell.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 script:
     content: |-
         $("#run").click(() => tryCatch(getTableCell));

--- a/samples/word/90-scenarios/doc-assembly.yaml
+++ b/samples/word/90-scenarios/doc-assembly.yaml
@@ -5,7 +5,7 @@ description: Composes different parts of a Word document.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |-
         $("#insert-header").click(() => tryCatch(insertHeader));

--- a/samples/word/90-scenarios/multiple-property-set.yaml
+++ b/samples/word/90-scenarios/multiple-property-set.yaml
@@ -5,7 +5,7 @@ description: Sets multiple properties at once with the API object set() method.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.3
+    WordApi: '1.3'
 script:
     content: |
         $("#set-multiple-properties-with-object").click(() => tryCatch(setMultiplePropertiesWithObject));

--- a/samples/word/default.yaml
+++ b/samples/word/default.yaml
@@ -4,7 +4,7 @@ description: Create a new snippet from a blank template.
 author: OfficeDev
 host: WORD
 api_set:
-    WordApi: 1.1
+    WordApi: '1.1'
 script:
     content: |
         $("#run").click(() => tryCatch(run));


### PR DESCRIPTION
The new guidance is to always use a string to represent the requirement set version. This PR updates the snippets to follow that guidance.