### PR TITLE
[excel] (Range.find) Addressing sample naming for ref doc snippets

### DIFF
--- a/samples/excel/42-range/range-find.yaml
+++ b/samples/excel/42-range/range-find.yaml
@@ -14,9 +14,9 @@ script:
         $("#toggleCase").click(() => tryCatch(toggleCase));
         $("#toggleDirection").click(() => tryCatch(toggleDirection));
 
-        let completeMatch  = false;
-        let matchCase = false;
-        let searchDirection = Excel.SearchDirection.forward;
+        let isCompleteMatchToggle  = false;
+        let isMatchCaseToggle = false;
+        let searchDirectionToggle = Excel.SearchDirection.forward;
 
         async function findText() {
             await Excel.run(async (context) => {
@@ -27,9 +27,9 @@ script:
                 // NOTE: If no match is found, an ItemNotFound error
                 // is thrown when Range.find is evaluated.
                 const foundRange = searchRange.find($("#searchText").text(), {
-                    completeMatch: completeMatch,
-                    matchCase: matchCase,
-                    searchDirection: searchDirection
+                    completeMatch: isCompleteMatchToggle,
+                    matchCase: isMatchCaseToggle,
+                    searchDirection: searchDirectionToggle
                 });
                 
                 foundRange.load("address");
@@ -46,9 +46,9 @@ script:
                 const table = sheet.tables.getItem("ExpensesTable");
                 const searchRange = table.getRange();
                 const foundRange = searchRange.findOrNullObject($("#searchText").text(), {
-                    completeMatch: completeMatch,
-                    matchCase: matchCase,
-                    searchDirection: searchDirection
+                    completeMatch: isCompleteMatchToggle,
+                    matchCase: isMatchCaseToggle,
+                    searchDirection: searchDirectionToggle
                 });
                 
                 foundRange.load("address");
@@ -63,18 +63,18 @@ script:
         }
 
         function toggleComplete() {
-            completeMatch = !completeMatch;
-            console.log("Finding complete match = " + completeMatch);
+            isCompleteMatchToggle = !isCompleteMatchToggle;
+            console.log("Finding complete match = " + isCompleteMatchToggle);
         }
 
         function toggleCase() {
-            matchCase = !matchCase;
-            console.log("Finding matched case = " + matchCase);
+            isMatchCaseToggle = !isMatchCaseToggle;
+            console.log("Finding matched case = " + isMatchCaseToggle);
         }
 
         function toggleDirection() {
-            searchDirection = searchDirection === Excel.SearchDirection.forward ? Excel.SearchDirection.backwards : Excel.SearchDirection.forward;
-            console.log("Search direction = " + searchDirection);
+            searchDirectionToggle = searchDirectionToggle === Excel.SearchDirection.forward ? Excel.SearchDirection.backwards : Excel.SearchDirection.forward;
+            console.log("Search direction = " + searchDirectionToggle);
         }
 
         async function setup() {

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -1879,9 +1879,9 @@ Excel.Range.find:
         // NOTE: If no match is found, an ItemNotFound error
         // is thrown when Range.find is evaluated.
         const foundRange = searchRange.find($("#searchText").text(), {
-            completeMatch: completeMatch,
-            matchCase: matchCase,
-            searchDirection: searchDirection
+            completeMatch: isCompleteMatchToggle,
+            matchCase: isMatchCaseToggle,
+            searchDirection: searchDirectionToggle
         });
         
         foundRange.load("address");
@@ -1897,9 +1897,9 @@ Excel.Range.findOrNullObject:
         const table = sheet.tables.getItem("ExpensesTable");
         const searchRange = table.getRange();
         const foundRange = searchRange.findOrNullObject($("#searchText").text(), {
-            completeMatch: completeMatch,
-            matchCase: matchCase,
-            searchDirection: searchDirection
+            completeMatch: isCompleteMatchToggle,
+            matchCase: isMatchCaseToggle,
+            searchDirection: searchDirectionToggle
         });
         
         foundRange.load("address");


### PR DESCRIPTION
This is to address https://github.com/OfficeDev/office-js-docs-reference/issues/504 downstream. Those variable names should up out of context in the methods when pulled from the snippet.