### PR TITLE
[excel] (CellProperties) Clarifying style input

### DIFF
--- a/samples/excel/42-range/cell-properties.yaml
+++ b/samples/excel/42-range/cell-properties.yaml
@@ -20,6 +20,7 @@ script:
                 // In your add-in, these should be created once, outside the function.
                 const topHeaderProps: Excel.SettableCellProperties = {
                     // The style property takes a string matching the name of an Excel style.
+                    // Built-in style names are listed in the `BuiltInStyle` enum.
                     // Note that a style will overwrite any formatting,
                     // so do not use the format property with the style property.
                     style: "Heading1"

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -57,6 +57,7 @@
         // In your add-in, these should be created once, outside the function.
         const topHeaderProps: Excel.SettableCellProperties = {
             // The style property takes a string matching the name of an Excel style.
+            // Built-in style names are listed in the `BuiltInStyle` enum.
             // Note that a style will overwrite any formatting,
             // so do not use the format property with the style property.
             style: "Heading1"
@@ -154,6 +155,7 @@
         // In your add-in, these should be created once, outside the function.
         const topHeaderProps: Excel.SettableCellProperties = {
             // The style property takes a string matching the name of an Excel style.
+            // Built-in style names are listed in the `BuiltInStyle` enum.
             // Note that a style will overwrite any formatting,
             // so do not use the format property with the style property.
             style: "Heading1"
@@ -1998,6 +2000,7 @@
         // In your add-in, these should be created once, outside the function.
         const topHeaderProps: Excel.SettableCellProperties = {
             // The style property takes a string matching the name of an Excel style.
+            // Built-in style names are listed in the `BuiltInStyle` enum.
             // Note that a style will overwrite any formatting,
             // so do not use the format property with the style property.
             style: "Heading1"
@@ -2541,6 +2544,7 @@
         // In your add-in, these should be created once, outside the function.
         const topHeaderProps: Excel.SettableCellProperties = {
             // The style property takes a string matching the name of an Excel style.
+            // Built-in style names are listed in the `BuiltInStyle` enum.
             // Note that a style will overwrite any formatting,
             // so do not use the format property with the style property.
             style: "Heading1"


### PR DESCRIPTION
(Based on an [internal work item](https://office.visualstudio.com/OC/_workitems/edit/3467808/))

`SettableCellProperties.style` can only take a limited set of strings: built-in style names and custom style names. This clarifies how to find the built-in names.