### PR TITLE
[excel] (Copy/Paste) Removing autofitColumns calls from copy and move snippets

### DIFF
--- a/samples/excel/42-range/range-copyfrom.yaml
+++ b/samples/excel/42-range/range-copyfrom.yaml
@@ -20,8 +20,8 @@ script:
         async function copyAll() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
+                // Place a label in front of the copied data.
                 sheet.getRange("F1").values = [["Copied Range"]];
-                sheet.getRange("F1").format.autofitColumns();
 
                 // Copy a range starting at a single cell destination.
                 sheet.getRange("G1").copyFrom("A1:E1");
@@ -32,8 +32,8 @@ script:
         async function copyFormula() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
+                // Place a label in front of the copied data.
                 sheet.getRange("F2").values = [["Copied Formula"]];
-                sheet.getRange("F2").format.autofitColumns();
 
                 // Copy a range preserving the formulas.
                 // Note: non-formula values are copied over as is.
@@ -45,8 +45,8 @@ script:
         async function copyFormulaResult() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
+                // Place a label in front of the copied data.
                 sheet.getRange("F3").values = [["Copied Formula Result"]];
-                sheet.getRange("F3").format.autofitColumns();
 
                 // Copy the resulting value of a formula.
                 sheet.getRange("G3").copyFrom("E1", Excel.RangeCopyType.values);
@@ -57,8 +57,8 @@ script:
         async function copySingleAcrossRange() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
+                // Place a label in front of the copied data.
                 sheet.getRange("F4").values = [["Single Source"]];
-                sheet.getRange("F4").format.autofitColumns();
 
                 // Copy a single cell across an entire range.
                 sheet.getRange("G4:K4").copyFrom("A1", Excel.RangeCopyType.values);
@@ -69,8 +69,8 @@ script:
         async function copyOnlyFormat() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
+                // Place a label in front of the copied data.
                 sheet.getRange("F5").values = [["Copied Formatting"]];
-                sheet.getRange("F5").format.autofitColumns();
 
                 // Copy only the formatting of the cells.
                 sheet.getRange("G5").copyFrom("A1:E1", Excel.RangeCopyType.formats);
@@ -81,8 +81,8 @@ script:
         async function skipBlanks() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
+                // Place a label in front of the copied data.
                 sheet.getRange("F6").values = [["Copied Without Blanks"]];
-                sheet.getRange("F6").format.autofitColumns();
 
                 // Fill the destination range so we can see the blank being skipped.
                 sheet.getRange("G6:K6").values = [["Old Data", "Old Data", "Old Data", "Old Data", "Old Data"]]
@@ -99,8 +99,8 @@ script:
         async function transpose() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
+                // Place a label in front of the transposed data.
                 sheet.getRange("F7").values = [["Transpose"]];
-                sheet.getRange("F7").format.autofitColumns();
 
                 // Transpose a horizontal range of data into a vertical range.
                 sheet.getRange("G7").copyFrom("A1:E1",
@@ -114,10 +114,10 @@ script:
         async function move() {
             await Excel.run(async (context) => {
                 const sheet = context.workbook.worksheets.getItem("Sample");
-                sheet.getRange("F12").values = [["Moved Range"]];
-                sheet.getRange("F12").format.autofitColumns();
+                // Place a label in front of the moved data.
+                sheet.getRange("F12").values = [["Moved Range:"]];
 
-                // Move a range to the specified location.
+                // Move the range from A1:E1 to G12:K12.
                 sheet.getRange("A1:E1").moveTo("G12");
                 await context.sync();
             });
@@ -134,7 +134,8 @@ script:
                 sheet.getRange("E1").formulas = [["=SUM(A1:D1)"]];
                 sheet.getRange("E1").format.font.bold = true;
                 sheet.getRange("E1").format.fill.color = "LightGreen";
-
+                sheet.getRange("F1").format.columnWidth = 120;
+                
                 sheet.activate();
                 await context.sync();
             });

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -2075,8 +2075,8 @@
   - |-
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sample");
+        // Place a label in front of the copied data.
         sheet.getRange("F2").values = [["Copied Formula"]];
-        sheet.getRange("F2").format.autofitColumns();
 
         // Copy a range preserving the formulas.
         // Note: non-formula values are copied over as is.
@@ -2362,10 +2362,10 @@
   - |-
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sample");
-        sheet.getRange("F12").values = [["Moved Range"]];
-        sheet.getRange("F12").format.autofitColumns();
+        // Place a label in front of the moved data.
+        sheet.getRange("F12").values = [["Moved Range:"]];
 
-        // Move a range to the specified location.
+        // Move the range from A1:E1 to G12:K12.
         sheet.getRange("A1:E1").moveTo("G12");
         await context.sync();
     });


### PR DESCRIPTION
This helps reduce extra code in the snippets destined for reference docs. 