### PR TITLE
[excel] (Performance) Adding performance note above suspendScreenUpdatingUntilNextSync

### DIFF
--- a/samples/excel/90-scenarios/performance-optimization.yaml
+++ b/samples/excel/90-scenarios/performance-optimization.yaml
@@ -25,6 +25,8 @@ script:
                 console.log("Starting...");
 
                 if (pauseScreenPainting) {
+                    // Note: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop).
+                    // Repeated calls will cause the Excel window to flicker. 
                     context.application.suspendScreenUpdatingUntilNextSync();
                 }
 

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -9,6 +9,8 @@
         console.log("Starting...");
 
         if (pauseScreenPainting) {
+            // Note: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop).
+            // Repeated calls will cause the Excel window to flicker. 
             context.application.suspendScreenUpdatingUntilNextSync();
         }
 


### PR DESCRIPTION
Calling `suspendScreenUpdatingUntilNextSync` in a loop causes the Excel window to flicker. This helps guide customers away from such behavior.