### PR TITLE
[admin] Updating linter settings

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -33,7 +33,6 @@
         "no-eval": true,
         "no-trailing-whitespace": true,
         "no-unused-expression": true,
-        "no-use-before-declare": true,
         "one-line": [
             true,
             "check-open-brace",


### PR DESCRIPTION
This removes the "no-use-before-declare is deprecated" warning message when running `yarn start`.