### PR TITLE
[Outlook] (compose) Snippet to add inline base64 image to message body

### DIFF
--- a/playlists-prod/outlook.yaml
+++ b/playlists-prod/outlook.yaml
@@ -37,6 +37,15 @@
   group: Item Body
   api_set:
     Mailbox: '1.1'
+- id: outlook-item-body-add-inline-base64-image
+  name: Add inline base64 image to message body (Compose)
+  fileName: add-inline-base64-image.yaml
+  description: Add an inline base64 image to the body of a message being composed.
+  rawUrl: >-
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/20-item-body/add-inline-base64-image.yaml
+  group: Item Body
+  api_set:
+    Mailbox: '1.8'
 - id: outlook-item-save-and-close-close
   name: Close the item
   fileName: close.yaml

--- a/playlists/outlook.yaml
+++ b/playlists/outlook.yaml
@@ -37,6 +37,15 @@
   group: Item Body
   api_set:
     Mailbox: '1.1'
+- id: outlook-item-body-add-inline-base64-image
+  name: Add inline base64 image to message body (Compose)
+  fileName: add-inline-base64-image.yaml
+  description: Add an inline base64 image to the body of a message being composed.
+  rawUrl: >-
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/20-item-body/add-inline-base64-image.yaml
+  group: Item Body
+  api_set:
+    Mailbox: '1.8'
 - id: outlook-item-save-and-close-close
   name: Close the item
   fileName: close.yaml

--- a/samples/outlook/20-item-body/add-inline-base64-image.yaml
+++ b/samples/outlook/20-item-body/add-inline-base64-image.yaml
@@ -22,7 +22,7 @@ script:
               mailItem.addFileAttachmentFromBase64Async(base64String, "sample.png", options, (attachResult) => {
                 if (attachResult.status === Office.AsyncResultStatus.Succeeded) {
                   let body = attachResult.asyncContext;
-                  body = body.replace("<p class=MsoNormal>", '<p class=MsoNormal><img src="cid:sample.png">');
+                  body = body.replace("<p class=MsoNormal>", `<p class=MsoNormal><img src="cid:sample.png">`);
 
                   mailItem.body.setAsync(body, { coercionType: Office.CoercionType.Html }, (setResult) => {
                     if (setResult.status === Office.AsyncResultStatus.Succeeded) {

--- a/samples/outlook/20-item-body/add-inline-base64-image.yaml
+++ b/samples/outlook/20-item-body/add-inline-base64-image.yaml
@@ -1,0 +1,82 @@
+order: 3
+id: outlook-item-body-add-inline-base64-image
+name: Add inline base64 image to message body (Compose)
+description: Add an inline base64 image to the body of a message being composed.
+host: OUTLOOK
+api_set:
+    Mailbox: '1.8'
+script:
+    content: |
+        $("#add-image").click(addImage);
+
+        function addImage() {
+          const mailItem = Office.context.mailbox.item;
+          const base64String =
+            "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAMAAADVRocKAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAnUExURQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN0S+bUAAAAMdFJOUwAQIDBAUI+fr7/P7yEupu8AAAAJcEhZcwAADsMAAA7DAcdvqGQAAAF8SURBVGhD7dfLdoMwDEVR6Cspzf9/b20QYOthS5Zn0Z2kVdY6O2WULrFYLBaLxd5ur4mDZD14b8ogWS/dtxV+dmx9ysA2QUj9TQRWv5D7HyKwuIW9n0vc8tkpHP0W4BOg3wQ8wtlvA+PC1e8Ao8Ld7wFjQtHvAiNC2e8DdqHqKwCrUPc1gE1AfRVgEXBfB+gF0lcCWoH2tYBOYPpqQCNwfT3QF9i+AegJfN8CtAWhbwJagtS3AbIg9o2AJMh9M5C+SVGBvx6zAfmT0r+Bv8JMwP4kyFPir+cswF5KL3WLv14zAFBCLf56Tw9cparFX4upgaJUtPhrOS1QlY5W+vWTXrGgBFB/b72ev3/0igUdQPppP/nfowfKUUEFcP207y/yxKmgAYQ+PywoAFOfCH3A2MdCFzD3kdADBvq10AGG+pXQBgb7pdAEhvuF0AIc/VtoAK7+JciAs38KIuDugyAC/v4hiMCE/i7IwLRBsh68N2WQjMVisVgs9i5bln8LGScNcCrONQAAAABJRU5ErkJggg==";
+
+          // Get the current body of the message.
+          mailItem.body.getAsync(Office.CoercionType.Html, (bodyResult) => {
+            if (bodyResult.status === Office.AsyncResultStatus.Succeeded) {
+              // Insert the base64 image to the beginning of the message body.
+              const options = { isInline: true, asyncContext: bodyResult.value };
+              mailItem.addFileAttachmentFromBase64Async(base64String, "sample.png", options, (attachResult) => {
+                if (attachResult.status === Office.AsyncResultStatus.Succeeded) {
+                  let body = attachResult.asyncContext;
+                  body = body.replace("<p class=MsoNormal>", '<p class=MsoNormal><img src="cid:sample.png">');
+
+                  mailItem.body.setAsync(body, { coercionType: Office.CoercionType.Html }, (setResult) => {
+                    if (setResult.status === Office.AsyncResultStatus.Succeeded) {
+                      console.log("Inline base64 image added to message.");
+                    } else {
+                      console.log(setResult.error.message);
+                    }
+                  });
+                } else {
+                  console.log(attachResult.error.message);
+                }
+              });
+            } else {
+              console.log(bodyResult.error.message);
+            }
+          });
+        }
+    language: typescript
+template:
+    content: |-
+        <section class=\"ms-font-m\">
+          <p class=\"ms-font-m\">This sample adds an inline base64 image to the body of the message being composed.</p>
+          <p><b>Required mode</b>: Compose</p>
+        </section>
+
+        <section class=\"samples ms-font-m\">
+          <h3>Try it out</h3>
+          <button id=\"add-image\" class=\"ms-Button\">
+            <span class=\"ms-Button-label\">Add an inline base64 image</span>
+          </button>
+        </section>
+    language: html
+style:
+    content: |-
+        section.samples {
+            margin-top: 20px;
+        }
+
+        section.samples .ms-Button, section.setup .ms-Button {
+            display: block;
+            margin-bottom: 5px;
+            margin-left: 20px;
+            min-width: 80px;
+        }
+    language: css
+libraries: |
+    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    @types/office-js
+
+    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+
+    core-js@2.4.1/client/core.min.js
+    @types/core-js
+
+    jquery@3.1.1
+    @types/jquery@3.3.1

--- a/view-prod/outlook.json
+++ b/view-prod/outlook.json
@@ -3,6 +3,7 @@
   "outlook-item-custom-properties-load-set-get-save": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/15-item-custom-properties/load-set-get-save.yaml",
   "outlook-item-body-get-selected-data": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/20-item-body/get-selected-data.yaml",
   "outlook-item-body-set-selected-data": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/20-item-body/set-selected-data.yaml",
+  "outlook-item-body-add-inline-base64-image": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/20-item-body/add-inline-base64-image.yaml",
   "outlook-item-save-and-close-close": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/25-item-save-and-close/close.yaml",
   "outlook-item-save-and-close-save": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/25-item-save-and-close/save.yaml",
   "outlook-recipients-and-attendees-get-from-message-read": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/30-recipients-and-attendees/get-from-message-read.yaml",

--- a/view/outlook.json
+++ b/view/outlook.json
@@ -3,6 +3,7 @@
   "outlook-item-custom-properties-load-set-get-save": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/15-item-custom-properties/load-set-get-save.yaml",
   "outlook-item-body-get-selected-data": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/20-item-body/get-selected-data.yaml",
   "outlook-item-body-set-selected-data": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/20-item-body/set-selected-data.yaml",
+  "outlook-item-body-add-inline-base64-image": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/20-item-body/add-inline-base64-image.yaml",
   "outlook-item-save-and-close-close": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/25-item-save-and-close/close.yaml",
   "outlook-item-save-and-close-save": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/25-item-save-and-close/save.yaml",
   "outlook-recipients-and-attendees-get-from-message-read": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/30-recipients-and-attendees/get-from-message-read.yaml",


### PR DESCRIPTION
This snippet will be referenced from [Add and remove attachments in an Outlook add-in](https://docs.microsoft.com/office/dev/add-ins/outlook/add-and-remove-attachments-to-an-item-in-a-compose-form).