### PR TITLE
[Outlook] (spam reporting) Create snippet for the getAsFileAsync method

### DIFF
--- a/playlists-prod/outlook.yaml
+++ b/playlists-prod/outlook.yaml
@@ -774,12 +774,12 @@
   group: Preview APIs
   api_set:
     Mailbox: preview
-- id: outlook-get-base64-encoding
-  name: Get the Base64 encoding of a message (Message Read)
-  fileName: get-base64-encoding.yaml
-  description: Gets the Base64 encoding of a message in read mode.
+- id: outlook-get-eml-format
+  name: Get the Base64-encoded EML format of a message (Message Read)
+  fileName: get-eml-format.yaml
+  description: Gets the Base64-encoded EML format of a message in read mode.
   rawUrl: >-
-    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/get-base64-encoding.yaml
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/get-eml-format.yaml
   group: Preview APIs
   api_set:
     Mailbox: preview

--- a/playlists-prod/outlook.yaml
+++ b/playlists-prod/outlook.yaml
@@ -774,3 +774,12 @@
   group: Preview APIs
   api_set:
     Mailbox: preview
+- id: outlook-get-base64-encoding
+  name: Get the Base64 encoding of a message (Message Read)
+  fileName: get-base64-encoding.yaml
+  description: Gets the Base64 encoding of a message in read mode.
+  rawUrl: >-
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/get-base64-encoding.yaml
+  group: Preview APIs
+  api_set:
+    Mailbox: preview

--- a/playlists/outlook.yaml
+++ b/playlists/outlook.yaml
@@ -774,12 +774,12 @@
   group: Preview APIs
   api_set:
     Mailbox: preview
-- id: outlook-get-base64-encoding
-  name: Get the Base64 encoding of a message (Message Read)
-  fileName: get-base64-encoding.yaml
-  description: Gets the Base64 encoding of a message in read mode.
+- id: outlook-get-eml-format
+  name: Get the Base64-encoded EML format of a message (Message Read)
+  fileName: get-eml-format.yaml
+  description: Gets the Base64-encoded EML format of a message in read mode.
   rawUrl: >-
-    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/get-base64-encoding.yaml
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/get-eml-format.yaml
   group: Preview APIs
   api_set:
     Mailbox: preview

--- a/playlists/outlook.yaml
+++ b/playlists/outlook.yaml
@@ -774,3 +774,12 @@
   group: Preview APIs
   api_set:
     Mailbox: preview
+- id: outlook-get-base64-encoding
+  name: Get the Base64 encoding of a message (Message Read)
+  fileName: get-base64-encoding.yaml
+  description: Gets the Base64 encoding of a message in read mode.
+  rawUrl: >-
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/get-base64-encoding.yaml
+  group: Preview APIs
+  api_set:
+    Mailbox: preview

--- a/samples/outlook/99-preview-apis/get-base64-encoding.yaml
+++ b/samples/outlook/99-preview-apis/get-base64-encoding.yaml
@@ -1,0 +1,61 @@
+order: 4
+id: outlook-get-base64-encoding
+name: Get the Base64 encoding of a message (Message Read)
+description: Gets the Base64 encoding of a message in read mode.
+host: OUTLOOK
+api_set:
+    Mailbox: preview
+script:
+    content: |
+        $("#get-base64-encoding").click(getBase64Encoding);
+
+        function getBase64Encoding() {
+          Office.context.mailbox.item.getAsFileAsync((asyncResult) => {
+            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
+              console.log(`Error encountered during processing: ${asyncResult.error.message}`);
+              return;
+            }
+
+            console.log(asyncResult.value);
+          });
+        }
+    language: typescript
+template:
+    content: |-
+        <section class="ms-font-m">
+            <p class="ms-font-m">This sample shows how to get the Base64 encoding of a message in read mode.</p>
+            <p><b>Required mode</b>: Message Read</p>
+        </section>
+
+        <section class="samples ms-font-m">
+            <h3>Try it out</h3>
+            <button id="get-base64-encoding" class="ms-Button">
+            <span class="ms-Button-label">Get Base64 encoding</span>
+          </button>
+        </section>
+    language: html
+style:
+    content: |-
+        section.samples {
+            margin-top: 20px;
+        }
+
+        section.samples .ms-Button, section.setup .ms-Button {
+            display: block;
+            margin-bottom: 5px;
+            margin-left: 20px;
+            min-width: 80px;
+        }
+    language: css
+libraries: |
+    https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
+    @types/office-js-preview
+
+    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+
+    core-js@2.4.1/client/core.min.js
+    @types/core-js
+
+    jquery@3.1.1
+    @types/jquery@3.3.1

--- a/samples/outlook/99-preview-apis/get-eml-format.yaml
+++ b/samples/outlook/99-preview-apis/get-eml-format.yaml
@@ -1,15 +1,15 @@
 order: 4
-id: outlook-get-base64-encoding
-name: Get the Base64 encoding of a message (Message Read)
-description: Gets the Base64 encoding of a message in read mode.
+id: outlook-get-eml-format
+name: Get the Base64-encoded EML format of a message (Message Read)
+description: Gets the Base64-encoded EML format of a message in read mode.
 host: OUTLOOK
 api_set:
     Mailbox: preview
 script:
     content: |
-        $("#get-base64-encoding").click(getBase64Encoding);
+        $("#get-eml-format").click(getEmlFormat);
 
-        function getBase64Encoding() {
+        function getEmlFormat() {
           Office.context.mailbox.item.getAsFileAsync((asyncResult) => {
             if (asyncResult.status === Office.AsyncResultStatus.Failed) {
               console.log(`Error encountered during processing: ${asyncResult.error.message}`);
@@ -23,14 +23,14 @@ script:
 template:
     content: |-
         <section class="ms-font-m">
-            <p class="ms-font-m">This sample shows how to get the Base64 encoding of a message in read mode.</p>
+            <p class="ms-font-m">This sample shows how to get the Base64-encoded EML format of a message in read mode.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
 
         <section class="samples ms-font-m">
             <h3>Try it out</h3>
-            <button id="get-base64-encoding" class="ms-Button">
-            <span class="ms-Button-label">Get Base64 encoding</span>
+            <button id="get-eml-format" class="ms-Button">
+            <span class="ms-Button-label">Get Base64-encoded EML format</span>
           </button>
         </section>
     language: html

--- a/view-prod/outlook.json
+++ b/view-prod/outlook.json
@@ -80,5 +80,6 @@
   "outlook-delay-message-delivery": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/90-other-item-apis/delay-message-delivery.yaml",
   "outlook-calendar-properties-apis": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/calendar-properties-apis.yaml",
   "outlook-close-async": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/close-async.yaml",
-  "outlook-set-displayed-body-subject": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml"
+  "outlook-set-displayed-body-subject": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml",
+  "outlook-get-base64-encoding": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/get-base64-encoding.yaml"
 }

--- a/view-prod/outlook.json
+++ b/view-prod/outlook.json
@@ -81,5 +81,5 @@
   "outlook-calendar-properties-apis": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/calendar-properties-apis.yaml",
   "outlook-close-async": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/close-async.yaml",
   "outlook-set-displayed-body-subject": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml",
-  "outlook-get-base64-encoding": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/get-base64-encoding.yaml"
+  "outlook-get-eml-format": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/99-preview-apis/get-eml-format.yaml"
 }

--- a/view/outlook.json
+++ b/view/outlook.json
@@ -81,5 +81,5 @@
   "outlook-calendar-properties-apis": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/calendar-properties-apis.yaml",
   "outlook-close-async": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/close-async.yaml",
   "outlook-set-displayed-body-subject": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml",
-  "outlook-get-base64-encoding": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/get-base64-encoding.yaml"
+  "outlook-get-eml-format": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/get-eml-format.yaml"
 }

--- a/view/outlook.json
+++ b/view/outlook.json
@@ -80,5 +80,6 @@
   "outlook-delay-message-delivery": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/90-other-item-apis/delay-message-delivery.yaml",
   "outlook-calendar-properties-apis": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/calendar-properties-apis.yaml",
   "outlook-close-async": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/close-async.yaml",
-  "outlook-set-displayed-body-subject": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml"
+  "outlook-set-displayed-body-subject": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml",
+  "outlook-get-base64-encoding": "https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/99-preview-apis/get-base64-encoding.yaml"
 }


### PR DESCRIPTION
Creates a code snippet for the `getAsFileAsync` method. This snippet will be added to the reference documentation in a separate PR (pending DT PR merge).

Related PRs:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66028
- https://github.com/OfficeDev/office-js-docs-reference/pull/1634
- https://github.com/OfficeDev/office-js-docs-pr/pull/4102