### PR TITLE
[Word] (footnotes) Remove online-only restriction

### DIFF
--- a/samples/word/50-document/manage-footnotes.yaml
+++ b/samples/word/50-document/manage-footnotes.yaml
@@ -139,13 +139,7 @@ script:
           });
         }
         async function setup() {
-          // Check for requirement set support and set two paragraphs of sample text.
-          if (!Office.context.requirements.isSetSupported("WordApiOnline", "1.1")) {
-            console.error(
-              "This version of Word doesn't support WordApiOnline 1.1 and so doesn't currently support the footnotes APIs."
-            );
-            return;
-          }
+          // Set two paragraphs of sample text.
           await Word.run(async (context) => {
             const body = context.document.body;
             body.clear();
@@ -175,9 +169,6 @@ template:
     content: |-
         <section class="ms-font-m">
             <p>This sample shows basic operations using footnotes.</p>
-        <p><b>Important</b>: The WordApiOnline 1.1 requirement set is needed for this sample. See <a target="_blank"
-                href="https://learn.microsoft.com/javascript/api/requirement-sets/word/word-api-requirement-sets">Word JavaScript
-                API requirement sets</a> for supported Word clients.</p>
         </section>
 
         <section class="setup ms-font-m">


### PR DESCRIPTION
Footnotes feature was released in WordApi 1.5 and so works in additional clients/platforms.