### PR TITLE
[Excel] (Data types) Expand functionality of error snippet

### DIFF
--- a/playlists-prod/excel.yaml
+++ b/playlists-prod/excel.yaml
@@ -331,9 +331,11 @@
   api_set:
     ExcelApi: '1.16'
 - id: excel-data-types-error-values
-  name: 'Data types: Set error values'
+  name: 'Data types: Set and change error values'
   fileName: data-types-error-values.yaml
-  description: This sample shows how to set a cell value to an error data type.
+  description: >-
+    This sample shows how to set a cell value to an error data type, and then
+    update the value of a cell that contains an error data type.
   rawUrl: >-
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/20-data-types/data-types-error-values.yaml
   group: Data Types

--- a/playlists-prod/excel.yaml
+++ b/playlists-prod/excel.yaml
@@ -335,7 +335,7 @@
   fileName: data-types-error-values.yaml
   description: >-
     This sample shows how to set a cell value to an error data type, and then
-    update the value of a cell that contains an error data type.
+    update the value of cells that contain an error data type.
   rawUrl: >-
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/20-data-types/data-types-error-values.yaml
   group: Data Types

--- a/playlists/excel.yaml
+++ b/playlists/excel.yaml
@@ -331,9 +331,11 @@
   api_set:
     ExcelApi: '1.16'
 - id: excel-data-types-error-values
-  name: 'Data types: Set error values'
+  name: 'Data types: Set and change error values'
   fileName: data-types-error-values.yaml
-  description: This sample shows how to set a cell value to an error data type.
+  description: >-
+    This sample shows how to set a cell value to an error data type, and then
+    update the value of a cell that contains an error data type.
   rawUrl: >-
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/excel/20-data-types/data-types-error-values.yaml
   group: Data Types

--- a/playlists/excel.yaml
+++ b/playlists/excel.yaml
@@ -335,7 +335,7 @@
   fileName: data-types-error-values.yaml
   description: >-
     This sample shows how to set a cell value to an error data type, and then
-    update the value of a cell that contains an error data type.
+    update the value of cells that contain an error data type.
   rawUrl: >-
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/excel/20-data-types/data-types-error-values.yaml
   group: Data Types

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -1,70 +1,97 @@
 order: 4
 id: excel-data-types-error-values
-name: 'Data types: Set error values'
-description: This sample shows how to set a cell value to an error data type.
+name: 'Data types: Set and change error values'
+description: This sample shows how to set a cell value to an error data type, and then update the value of a cell that contains an error data type.
 host: EXCEL
 api_set:
     ExcelApi: '1.16'
 script:
     content: |
-        $("#setup").click(() => tryCatch(setup));
-        $("#setBusyError").click(() => tryCatch(setBusyError));
+      $("#setup").click(() => tryCatch(setup));
+      $("#set-busy-error").click(() => tryCatch(setBusyError));
+      $("#change-busy-error").click(() => tryCatch(changeBusyError));
+      
+      async function setBusyError() {
+        // This function sets the value of cell A1 to a #BUSY! error using data types.
+        await Excel.run(async (context) => {
+          // Retrieve the Sample worksheet and cell A1 on that sheet.
+          const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
+          const range = sheet.getRange("A1");
+          
+          // Get the error data type and set its type to `busy`.
+          const error: Excel.ErrorCellValue = {
+            type: Excel.CellValueType.error,
+            errorType: Excel.ErrorCellValueType.busy
+          };
+          
+          // Set cell A1 as the busy error.
+          range.valuesAsJson = [[error]];
+          await context.sync();
+        });
+      }
 
-        async function setBusyError() {
-          // This function sets the value of cell A1 to a #BUSY! error using data types.
-          await Excel.run(async (context) => {
-            // Retrieve the Sample worksheet and cell A1 on that sheet.
-            const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
-            const range = sheet.getRange("A1");
-
-            // Get the error data type and set its type to `busy`. 
-            const error: Excel.ErrorCellValue = {
-              type: Excel.CellValueType.error,
-              errorType: Excel.ErrorCellValueType.busy
-            };
-
-            // Set cell A1 as the busy error.
-            range.valuesAsJson = [[error]];
+      async function changeBusyError() {
+        // This function checks if a range contains a #BUSY! error, and then updates the range if it contains the error.
+        await Excel.run(async (context) => {
+          // Retrieve the Sample worksheet and cell A1 on that sheet.
+          const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
+          const range = sheet.getRange("A1");
+          
+          // Load the `valuesAsJson` property for comparison.
+          range.load("valuesAsJson");
+          await context.sync();
+          
+          // Check if the range contains a #BUSY! error.
+          if (range.valuesAsJson[0][0]["errorType"] == Excel.ErrorCellValueType.busy) {
+            // If the range contains a #BUSY! error, load and change the value of the range.
+            range.load("values");
             await context.sync();
-          });
-        }
-
-        async function setup() {
-          await Excel.run(async (context) => {
-            // Create a new worksheet called "Sample" and activate it.
-            context.workbook.worksheets.getItemOrNullObject("Sample").delete();
-            const sheet = context.workbook.worksheets.add("Sample");
-            sheet.activate();
-
-            await context.sync();
-          });
-        }
-
-        /** Default helper for invoking an action and handling errors. */
-        async function tryCatch(callback) {
-          try {
-            await callback();
-          } catch (error) {
-            // Note: In a production add-in, you'd want to notify the user through your add-in's UI.
-            console.error(error);
+            range.values = [["Process unavailable."]];
           }
+          
+          await context.sync();
+        });
+      }
+
+      async function setup() {
+        await Excel.run(async (context) => {
+          // Create a new worksheet called "Sample" and activate it.
+          context.workbook.worksheets.getItemOrNullObject("Sample").delete();
+          const sheet = context.workbook.worksheets.add("Sample");
+          sheet.activate();
+          await context.sync();
+        });
+      }
+
+      /** Default helper for invoking an action and handling errors. */
+      async function tryCatch(callback) {
+        try {
+          await callback();
+        } catch (error) {
+          // Note: In a production add-in, you'd want to notify the user through your add-in's UI.
+          console.error(error);
         }
+      }
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
-          <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type.</p>
-        </section>
-        <section class="setup ms-font-m">
-          <h3>Set up</h3>
-          <button id="setup" class="ms-Button">
-            <span class="ms-Button-label">Add worksheet</span>
-          </button>
-          <h3>Try it out</h3>
-          <button id="setBusyError" class="ms-Button">
-            <span class="ms-Button-label">Set A1 to busy error</span>
-          </button>
-        </section>
+      <section class="ms-font-m">
+        <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if
+          cell A1 contains a #BUSY! error, and updates the cell value if it does.</p>
+      </section>
+      <section class="setup ms-font-m">
+        <h3>Set up</h3>
+        <button id="setup" class="ms-Button">
+          <span class="ms-Button-label">Add worksheet</span>
+        </button>
+        <h3>Try it out</h3>
+        <button id="set-busy-error" class="ms-Button">
+          <span class="ms-Button-label">Set A1 to #BUSY! error</span>
+        </button>
+        <button id="change-busy-error" class="ms-Button">
+          <span class="ms-Button-label">Change output of cell with #BUSY! error</span>
+        </button>
+      </section>
     language: html
 style:
     content: |-

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -75,22 +75,22 @@ script:
     language: typescript
 template:
     content: |-
-      <section class="ms-font-m">
-        <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if the worksheet contains a #BUSY! error, and then updates all cells that contain a #BUSY! error.</p>
-      </section>
-      <section class="setup ms-font-m">
-        <h3>Set up</h3>
-        <button id="setup" class="ms-Button">
-          <span class="ms-Button-label">Add worksheet</span>
-        </button>
-        <h3>Try it out</h3>
-        <button id="set-busy-error" class="ms-Button">
-          <span class="ms-Button-label">Set A1 to #BUSY! error</span>
-        </button>
-        <button id="change-busy-error" class="ms-Button">
-          <span class="ms-Button-label">Change output of cells with #BUSY! error</span>
-        </button>
-      </section>
+        <section class="ms-font-m">
+          <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if the worksheet contains a #BUSY! error, and then updates all cells that contain a #BUSY! error.</p>
+        </section>
+        <section class="setup ms-font-m">
+          <h3>Set up</h3>
+          <button id="setup" class="ms-Button">
+            <span class="ms-Button-label">Add worksheet</span>
+          </button>
+          <h3>Try it out</h3>
+          <button id="set-busy-error" class="ms-Button">
+            <span class="ms-Button-label">Set A1 to #BUSY! error</span>
+          </button>
+          <button id="change-busy-error" class="ms-Button">
+            <span class="ms-Button-label">Change output of cells with #BUSY! error</span>
+          </button>
+        </section>
     language: html
 style:
     content: |-

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -89,7 +89,7 @@ template:
             <span class="ms-Button-label">Set A1 to #BUSY! error</span>
           </button>
           <button id="change-busy-error" class="ms-Button">
-            <span class="ms-Button-label">Change output of cell with #BUSY! error</span>
+            <span class="ms-Button-label">Change #BUSY! error cell value</span>
           </button>
         </section>
     language: html

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -1,97 +1,97 @@
 order: 4
 id: excel-data-types-error-values
 name: 'Data types: Set and change error values'
-description: This sample shows how to set a cell value to an error data type, and then update the value of a cell that contains an error data type.
+description: 'This sample shows how to set a cell value to an error data type, and then update the value of a cell that contains an error data type.'
 host: EXCEL
 api_set:
     ExcelApi: '1.16'
 script:
     content: |
-      $("#setup").click(() => tryCatch(setup));
-      $("#set-busy-error").click(() => tryCatch(setBusyError));
-      $("#change-busy-error").click(() => tryCatch(changeBusyError));
-      
-      async function setBusyError() {
-        // This function sets the value of cell A1 to a #BUSY! error using data types.
-        await Excel.run(async (context) => {
-          // Retrieve the Sample worksheet and cell A1 on that sheet.
-          const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
-          const range = sheet.getRange("A1");
-          
-          // Get the error data type and set its type to `busy`.
-          const error: Excel.ErrorCellValue = {
-            type: Excel.CellValueType.error,
-            errorType: Excel.ErrorCellValueType.busy
-          };
-          
-          // Set cell A1 as the busy error.
-          range.valuesAsJson = [[error]];
-          await context.sync();
-        });
-      }
+        $("#setup").click(() => tryCatch(setup));
+        $("#set-busy-error").click(() => tryCatch(setBusyError));
+        $("#change-busy-error").click(() => tryCatch(changeBusyError));
 
-      async function changeBusyError() {
-        // This function checks if a range contains a #BUSY! error, and then updates the range if it contains the error.
-        await Excel.run(async (context) => {
-          // Retrieve the Sample worksheet and cell A1 on that sheet.
-          const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
-          const range = sheet.getRange("A1");
-          
-          // Load the `valuesAsJson` property for comparison.
-          range.load("valuesAsJson");
-          await context.sync();
-          
-          // Check if the range contains a #BUSY! error.
-          if (range.valuesAsJson[0][0]["errorType"] == Excel.ErrorCellValueType.busy) {
-            // If the range contains a #BUSY! error, load and change the value of the range.
-            range.load("values");
+        async function setBusyError() {
+          // This function sets the value of cell A1 to a #BUSY! error using data types.
+          await Excel.run(async (context) => {
+            // Retrieve the Sample worksheet and cell A1 on that sheet.
+            const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
+            const range = sheet.getRange("A1");
+            
+            // Get the error data type and set its type to `busy`.
+            const error: Excel.ErrorCellValue = {
+              type: Excel.CellValueType.error,
+              errorType: Excel.ErrorCellValueType.busy
+            };
+            
+            // Set cell A1 as the busy error.
+            range.valuesAsJson = [[error]];
             await context.sync();
-            range.values = [["Process unavailable."]];
-          }
-          
-          await context.sync();
-        });
-      }
-
-      async function setup() {
-        await Excel.run(async (context) => {
-          // Create a new worksheet called "Sample" and activate it.
-          context.workbook.worksheets.getItemOrNullObject("Sample").delete();
-          const sheet = context.workbook.worksheets.add("Sample");
-          sheet.activate();
-          await context.sync();
-        });
-      }
-
-      /** Default helper for invoking an action and handling errors. */
-      async function tryCatch(callback) {
-        try {
-          await callback();
-        } catch (error) {
-          // Note: In a production add-in, you'd want to notify the user through your add-in's UI.
-          console.error(error);
+          });
         }
-      }
+
+        async function changeBusyError() {
+          // This function checks if a range contains a #BUSY! error, and then updates the range if it contains the error.
+          await Excel.run(async (context) => {
+            // Retrieve the Sample worksheet and cell A1 on that sheet.
+            const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
+            const range = sheet.getRange("A1");
+            
+            // Load the `valuesAsJson` property for comparison.
+            range.load("valuesAsJson");
+            await context.sync();
+            
+            // Check if the range contains a #BUSY! error.
+            if (range.valuesAsJson[0][0]["errorType"] == Excel.ErrorCellValueType.busy) {
+              // If the range contains a #BUSY! error, load and change the value of the range.
+              range.load("values");
+              await context.sync();
+              range.values = [["Process unavailable."]];
+            }
+            
+            await context.sync();
+          });
+        }
+
+        async function setup() {
+          await Excel.run(async (context) => {
+            // Create a new worksheet called "Sample" and activate it.
+            context.workbook.worksheets.getItemOrNullObject("Sample").delete();
+            const sheet = context.workbook.worksheets.add("Sample");
+            sheet.activate();
+            await context.sync();
+          });
+        }
+
+        /** Default helper for invoking an action and handling errors. */
+        async function tryCatch(callback) {
+          try {
+            await callback();
+          } catch (error) {
+            // Note: In a production add-in, you'd want to notify the user through your add-in's UI.
+            console.error(error);
+          }
+        }
     language: typescript
 template:
     content: |-
-      <section class="ms-font-m">
-        <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if
-          cell A1 contains a #BUSY! error, and updates the cell value if it does.</p>
-      </section>
-      <section class="setup ms-font-m">
-        <h3>Set up</h3>
-        <button id="setup" class="ms-Button">
-          <span class="ms-Button-label">Add worksheet</span>
-        </button>
-        <h3>Try it out</h3>
-        <button id="set-busy-error" class="ms-Button">
-          <span class="ms-Button-label">Set A1 to #BUSY! error</span>
-        </button>
-        <button id="change-busy-error" class="ms-Button">
-          <span class="ms-Button-label">Change output of cell with #BUSY! error</span>
-        </button>
-      </section>
+        <section class="ms-font-m">
+          <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if
+            cell A1 contains a #BUSY! error, and updates the cell value if it does.</p>
+        </section>
+        <section class="setup ms-font-m">
+          <h3>Set up</h3>
+          <button id="setup" class="ms-Button">
+            <span class="ms-Button-label">Add worksheet</span>
+          </button>
+          <h3>Try it out</h3>
+          <button id="set-busy-error" class="ms-Button">
+            <span class="ms-Button-label">Set A1 to #BUSY! error</span>
+          </button>
+          <button id="change-busy-error" class="ms-Button">
+            <span class="ms-Button-label">Change output of cell with #BUSY! error</span>
+          </button>
+        </section>
     language: html
 style:
     content: |-

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -17,13 +17,13 @@ script:
             // Retrieve the Sample worksheet and cell A1 on that sheet.
             const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
             const range = sheet.getRange("A1");
-            
+
             // Get the error data type and set its type to `busy`.
             const error: Excel.ErrorCellValue = {
               type: Excel.CellValueType.error,
               errorType: Excel.ErrorCellValueType.busy
             };
-            
+
             // Set cell A1 as the busy error.
             range.valuesAsJson = [[error]];
             await context.sync();
@@ -36,11 +36,11 @@ script:
             // Retrieve the Sample worksheet and cell A1 on that sheet.
             const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
             const range = sheet.getRange("A1");
-            
+
             // Load the `valuesAsJson` property for comparison.
             range.load("valuesAsJson");
             await context.sync();
-            
+
             // Check if the range contains a #BUSY! error.
             if (range.valuesAsJson[0][0]["errorType"] == Excel.ErrorCellValueType.busy) {
               // If the range contains a #BUSY! error, load and change the value of the range.
@@ -48,7 +48,7 @@ script:
               await context.sync();
               range.values = [["Process unavailable."]];
             }
-            
+
             await context.sync();
           });
         }

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -1,7 +1,7 @@
 order: 4
 id: excel-data-types-error-values
 name: 'Data types: Set and change error values'
-description: 'This sample shows how to set a cell value to an error data type, and then update the value of a cell that contains an error data type.'
+description: 'This sample shows how to set a cell value to an error data type, and then update the value of cells that contain an error data type.'
 host: EXCEL
 api_set:
     ExcelApi: '1.16'
@@ -31,22 +31,22 @@ script:
         }
 
         async function changeBusyError() {
-          // This function checks if a range contains a #BUSY! error, and then updates the range if it contains the error.
+          // This function checks if the used range contains a #BUSY! error, and then updates all the cells in the range that contain the error.
           await Excel.run(async (context) => {
-            // Retrieve the Sample worksheet and cell A1 on that sheet.
+            // Retrieve the Sample worksheet and the used range on that sheet.
             const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
-            const range = sheet.getRange("A1");
+            const usedRange = sheet.getUsedRange();
 
             // Load the `valuesAsJson` property for comparison.
-            range.load("valuesAsJson");
+            usedRange.load("valuesAsJson");
             await context.sync();
 
-            // Check if the range contains a #BUSY! error.
-            if (range.valuesAsJson[0][0]["errorType"] == Excel.ErrorCellValueType.busy) {
-              // If the range contains a #BUSY! error, load and change the value of the range.
-              range.load("values");
+            // Check if the used range contains a #BUSY! error.
+            if (usedRange.valuesAsJson[0][0]["errorType"] == Excel.ErrorCellValueType.busy) {
+              // If the used range contains a #BUSY! error, load and change those values.
+              usedRange.load("values");
               await context.sync();
-              range.values = [["Process unavailable."]];
+              usedRange.values = [["Process unavailable."]];
             }
 
             await context.sync();
@@ -75,23 +75,22 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
-          <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if
-            cell A1 contains a #BUSY! error, and updates the cell value if it does.</p>
-        </section>
-        <section class="setup ms-font-m">
-          <h3>Set up</h3>
-          <button id="setup" class="ms-Button">
-            <span class="ms-Button-label">Add worksheet</span>
-          </button>
-          <h3>Try it out</h3>
-          <button id="set-busy-error" class="ms-Button">
-            <span class="ms-Button-label">Set A1 to #BUSY! error</span>
-          </button>
-          <button id="change-busy-error" class="ms-Button">
-            <span class="ms-Button-label">Change #BUSY! error cell value</span>
-          </button>
-        </section>
+      <section class="ms-font-m">
+        <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if the worksheet contains a #BUSY! error, and then updates all cells that contain a #BUSY! error.</p>
+      </section>
+      <section class="setup ms-font-m">
+        <h3>Set up</h3>
+        <button id="setup" class="ms-Button">
+          <span class="ms-Button-label">Add worksheet</span>
+        </button>
+        <h3>Try it out</h3>
+        <button id="set-busy-error" class="ms-Button">
+          <span class="ms-Button-label">Set A1 to #BUSY! error</span>
+        </button>
+        <button id="change-busy-error" class="ms-Button">
+          <span class="ms-Button-label">Change output of cells with #BUSY! error</span>
+        </button>
+      </section>
     language: html
 style:
     content: |-

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -705,13 +705,13 @@
       // Retrieve the Sample worksheet and cell A1 on that sheet.
       const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
       const range = sheet.getRange("A1");
-      
+
       // Get the error data type and set its type to `busy`.
       const error: Excel.ErrorCellValue = {
         type: Excel.CellValueType.error,
         errorType: Excel.ErrorCellValueType.busy
       };
-      
+
       // Set cell A1 as the busy error.
       range.valuesAsJson = [[error]];
       await context.sync();
@@ -3320,13 +3320,13 @@
       // Retrieve the Sample worksheet and cell A1 on that sheet.
       const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
       const range = sheet.getRange("A1");
-      
+
       // Get the error data type and set its type to `busy`.
       const error: Excel.ErrorCellValue = {
         type: Excel.CellValueType.error,
         errorType: Excel.ErrorCellValueType.busy
       };
-      
+
       // Set cell A1 as the busy error.
       range.valuesAsJson = [[error]];
       await context.sync();
@@ -3343,13 +3343,13 @@
       // Retrieve the Sample worksheet and cell A1 on that sheet.
       const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
       const range = sheet.getRange("A1");
-      
+
       // Get the error data type and set its type to `busy`.
       const error: Excel.ErrorCellValue = {
         type: Excel.CellValueType.error,
         errorType: Excel.ErrorCellValueType.busy
       };
-      
+
       // Set cell A1 as the busy error.
       range.valuesAsJson = [[error]];
       await context.sync();

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -705,13 +705,13 @@
       // Retrieve the Sample worksheet and cell A1 on that sheet.
       const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
       const range = sheet.getRange("A1");
-
-      // Get the error data type and set its type to `busy`. 
+      
+      // Get the error data type and set its type to `busy`.
       const error: Excel.ErrorCellValue = {
         type: Excel.CellValueType.error,
         errorType: Excel.ErrorCellValueType.busy
       };
-
+      
       // Set cell A1 as the busy error.
       range.valuesAsJson = [[error]];
       await context.sync();
@@ -3320,13 +3320,13 @@
       // Retrieve the Sample worksheet and cell A1 on that sheet.
       const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
       const range = sheet.getRange("A1");
-
-      // Get the error data type and set its type to `busy`. 
+      
+      // Get the error data type and set its type to `busy`.
       const error: Excel.ErrorCellValue = {
         type: Excel.CellValueType.error,
         errorType: Excel.ErrorCellValueType.busy
       };
-
+      
       // Set cell A1 as the busy error.
       range.valuesAsJson = [[error]];
       await context.sync();
@@ -3343,13 +3343,13 @@
       // Retrieve the Sample worksheet and cell A1 on that sheet.
       const sheet = context.workbook.worksheets.getItemOrNullObject("Sample");
       const range = sheet.getRange("A1");
-
-      // Get the error data type and set its type to `busy`. 
+      
+      // Get the error data type and set its type to `busy`.
       const error: Excel.ErrorCellValue = {
         type: Excel.CellValueType.error,
         errorType: Excel.ErrorCellValueType.busy
       };
-
+      
       // Set cell A1 as the busy error.
       range.valuesAsJson = [[error]];
       await context.sync();


### PR DESCRIPTION
This update addresses a customer documentation request by showing how to control the output of a data type cell, if the data type returns as an error. 

Customer request: https://github.com/OfficeDev/Office-Add-in-samples/issues/630