### PR TITLE
[Outlook] (notifications) Fix insight notification snippet

### DIFF
--- a/playlists-prod/outlook.yaml
+++ b/playlists-prod/outlook.yaml
@@ -247,8 +247,8 @@
   name: Work with notification messages
   fileName: add-getall-remove.yaml
   description: >-
-    Adds different kinds of notification messages, gets all, and replaces and
-    removes an individual notification message.
+    Adds different kinds of notification messages, gets all notifications, and
+    replaces and removes an individual notification message.
   rawUrl: >-
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/outlook/35-notifications/add-getall-remove.yaml
   group: Notifications

--- a/playlists/outlook.yaml
+++ b/playlists/outlook.yaml
@@ -247,8 +247,8 @@
   name: Work with notification messages
   fileName: add-getall-remove.yaml
   description: >-
-    Adds different kinds of notification messages, gets all, and replaces and
-    removes an individual notification message.
+    Adds different kinds of notification messages, gets all notifications, and
+    replaces and removes an individual notification message.
   rawUrl: >-
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/main/samples/outlook/35-notifications/add-getall-remove.yaml
   group: Notifications

--- a/samples/outlook/35-notifications/add-getall-remove.yaml
+++ b/samples/outlook/35-notifications/add-getall-remove.yaml
@@ -56,39 +56,21 @@ script:
           // Adds an informational message with actions to the mail item.
           const id = $("#notificationId").val().toString();
 
-          let details;
-          // Identify whether the current mail item is in read or compose mode.
-          if (Office.context.mailbox.item.itemId != undefined) {
-            // Read mode.
-            details = {
-              type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-              message: "This is an insight notification with id = " + id,
-              icon: "icon1",
-              actions: [
-                {
-                  actionText: "Open insight",
-                  actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-                  commandId: "PG.HelpCommand.Read",
-                  contextData: { a: "aValue", b: "bValue" }
-                }
-              ]
-            };
-          } else {
-            // Compose mode.
-            details = {
-              type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-              message: "This is an insight notification with id = " + id,
-              icon: "icon1",
-              actions: [
-                {
-                  actionText: "Open insight",
-                  actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-                  commandId: "PG.HelpCommand.Compose",
-                  contextData: { a: "aValue", b: "bValue" }
-                }
-              ]
-            };
-          }
+          const itemId = Office.context.mailbox.item.itemId;
+          const details = {
+            type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
+            message: "This is an insight notification with id = " + id,
+            icon: "icon1",
+            actions: [
+              {
+                actionText: "Open insight",
+                actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
+                // Identify whether the current mail item is in read or compose mode to set the appropriate commandId value.
+                commandId: (itemId == undefined ? "PG.HelpCommand.Compose" : "PG.HelpCommand.Read"),
+                contextData: { a: "aValue", b: "bValue" }
+              }
+            ]
+          };
 
           Office.context.mailbox.item.notificationMessages.addAsync(id, details, handleResult);
         }

--- a/samples/outlook/35-notifications/add-getall-remove.yaml
+++ b/samples/outlook/35-notifications/add-getall-remove.yaml
@@ -57,7 +57,7 @@ script:
           const id = $("#notificationId").val().toString();
 
           let details;
-          // Identifies whether the current mail item is in read or compose mode.
+          // Identify whether the current mail item is in read or compose mode.
           if (Office.context.mailbox.item.itemId != undefined) {
             // Read mode.
             details = {
@@ -148,9 +148,9 @@ template:
         </section>
 
         <section class="samples ms-font-m">
-          <h2>Try it out</h3>
+          <h2>Try it out</h2>
           <div class="ms-TextField">
-            <label class="ms-Label">Notification ID to add, replace, or remove a notification:</label>
+            <label class="ms-Label">Notification ID to add, replace, or remove that notification:</label>
             <input id="notificationId" class="ms-TextField-field" type="text" value="my_id_00" placeholder="">
           </div>
           <h3>Add a notification</h3>

--- a/samples/outlook/35-notifications/add-getall-remove.yaml
+++ b/samples/outlook/35-notifications/add-getall-remove.yaml
@@ -1,6 +1,6 @@
 id: outlook-notifications-add-getall-remove
 name: Work with notification messages
-description: 'Adds different kinds of notification messages, gets all, and replaces and removes an individual notification message.'
+description: 'Adds different kinds of notification messages, gets all notifications, and replaces and removes an individual notification message.'
 host: OUTLOOK
 api_set:
     Mailbox: '1.10'
@@ -55,20 +55,41 @@ script:
         function addInsight() {
           // Adds an informational message with actions to the mail item.
           const id = $("#notificationId").val().toString();
-          const details = 
-            {
+
+          let details;
+          // Identifies whether the current mail item is in read or compose mode.
+          if (Office.context.mailbox.item.itemId != undefined) {
+            // Read mode.
+            details = {
               type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-              message: "This is an insight notification",
+              message: "This is an insight notification with id = " + id,
               icon: "icon1",
               actions: [
                 {
                   actionText: "Open insight",
                   actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-                  commandId: "msgComposeOpenPaneButton",
+                  commandId: "PG.HelpCommand.Read",
                   contextData: { a: "aValue", b: "bValue" }
                 }
               ]
             };
+          } else {
+            // Compose mode.
+            details = {
+              type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
+              message: "This is an insight notification with id = " + id,
+              icon: "icon1",
+              actions: [
+                {
+                  actionText: "Open insight",
+                  actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
+                  commandId: "PG.HelpCommand.Compose",
+                  contextData: { a: "aValue", b: "bValue" }
+                }
+              ]
+            };
+          }
+
           Office.context.mailbox.item.notificationMessages.addAsync(id, details, handleResult);
         }
 
@@ -127,34 +148,51 @@ template:
         </section>
 
         <section class="samples ms-font-m">
-          <h3>Try it out</h3>
+          <h2>Try it out</h3>
           <div class="ms-TextField">
-            <label class="ms-Label">Notification ID to use with add/replace/remove:</label>
+            <label class="ms-Label">Notification ID to add, replace, or remove a notification:</label>
             <input id="notificationId" class="ms-TextField-field" type="text" value="my_id_00" placeholder="">
           </div>
+          <h3>Add a notification</h3>
+          <p>To add a notification, enter a unique ID for the notification in the text field, then select one of the notification types below.</p>
+          <p><b>Note</b>:</p>
+          <ul>
+            <li>You can add a maximum of five notifications per mail item.</li>
+            <li>You can only add one insight notification to a mail item.</li>
+            <li>In Outlook on the web, you can only add an insight notification to an item in compose mode.</li>
+          </ul>
           <button id="addProgress" class="ms-Button">
             <div class="ms-Button-label">Add a progress notification</div>
           </button>
+          <br>
           <button id="addInformational" class="ms-Button">
             <div class="ms-Button-label">Add an informational notification</div>
           </button>
+          <br>
           <button id="addInformationalPersisted" class="ms-Button">
             <div class="ms-Button-label">Add a persisted informational notification</div>
           </button>
+          <br>
           <button id="addInsight" class="ms-Button">
             <div class="ms-Button-label">Add an insight notification</div>
           </button>
+          <br>
           <button id="addError" class="ms-Button">
             <div class="ms-Button-label">Add an error notification</div>
           </button>
+          <h3>Get all notifications</h3>
           <button id="getAll" class="ms-Button">
-            <div class="ms-Button-label">Get all</div>
+            <div class="ms-Button-label">Get notifications</div>
           </button>
+          <h3>Replace a notificationId</h3>
+          <p>To replace a notification with an informational message, enter the ID of the notification you want to replace in the text field, then select <b>Replace notification</b>.</p>
           <button id="replace" class="ms-Button">
-            <div class="ms-Button-label">Replace</div>
+            <div class="ms-Button-label">Replace notification</div>
           </button>
+          <h3>Remove a notification</h3>
+          <p>To remove a notification, enter the ID of the notification you want to remove in the text field, then select <b>Remove notification</b>.</p>
           <button id="remove" class="ms-Button">
-            <div class="ms-Button-label">Remove</div>
+            <div class="ms-Button-label">Remove notification</div>
           </button>
         </section>
     language: html

--- a/samples/outlook/35-notifications/add-getall-remove.yaml
+++ b/samples/outlook/35-notifications/add-getall-remove.yaml
@@ -166,7 +166,7 @@ template:
           <button id="getAll" class="ms-Button">
             <div class="ms-Button-label">Get notifications</div>
           </button>
-          <h3>Replace a notificationId</h3>
+          <h3>Replace a notification</h3>
           <p>To replace a notification with an informational message, enter the ID of the notification you want to replace in the text field, then select <b>Replace notification</b>.</p>
           <button id="replace" class="ms-Button">
             <div class="ms-Button-label">Replace notification</div>

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -10456,20 +10456,44 @@
 
     const id = $("#notificationId").val().toString();
 
-    const details = 
-      {
+
+    let details;
+
+    // Identifies whether the current mail item is in read or compose mode.
+
+    if (Office.context.mailbox.item.itemId != undefined) {
+      // Read mode.
+      details = {
         type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-        message: "This is an insight notification",
+        message: "This is an insight notification with id = " + id,
         icon: "icon1",
         actions: [
           {
             actionText: "Open insight",
             actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-            commandId: "msgComposeOpenPaneButton",
+            commandId: "PG.HelpCommand.Read",
             contextData: { a: "aValue", b: "bValue" }
           }
         ]
       };
+    } else {
+      // Compose mode.
+      details = {
+        type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
+        message: "This is an insight notification with id = " + id,
+        icon: "icon1",
+        actions: [
+          {
+            actionText: "Open insight",
+            actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
+            commandId: "PG.HelpCommand.Compose",
+            contextData: { a: "aValue", b: "bValue" }
+          }
+        ]
+      };
+    }
+
+
     Office.context.mailbox.item.notificationMessages.addAsync(id, details,
     handleResult);
 'Office.MailboxEnums.AppointmentSensitivityType:enum':
@@ -12691,20 +12715,44 @@
 
     const id = $("#notificationId").val().toString();
 
-    const details = 
-      {
+
+    let details;
+
+    // Identifies whether the current mail item is in read or compose mode.
+
+    if (Office.context.mailbox.item.itemId != undefined) {
+      // Read mode.
+      details = {
         type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-        message: "This is an insight notification",
+        message: "This is an insight notification with id = " + id,
         icon: "icon1",
         actions: [
           {
             actionText: "Open insight",
             actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-            commandId: "msgComposeOpenPaneButton",
+            commandId: "PG.HelpCommand.Read",
             contextData: { a: "aValue", b: "bValue" }
           }
         ]
       };
+    } else {
+      // Compose mode.
+      details = {
+        type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
+        message: "This is an insight notification with id = " + id,
+        icon: "icon1",
+        actions: [
+          {
+            actionText: "Open insight",
+            actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
+            commandId: "PG.HelpCommand.Compose",
+            contextData: { a: "aValue", b: "bValue" }
+          }
+        ]
+      };
+    }
+
+
     Office.context.mailbox.item.notificationMessages.addAsync(id, details,
     handleResult);
 'Office.NotificationMessageDetails:interface':

--- a/snippet-extractor-output/snippets.yaml
+++ b/snippet-extractor-output/snippets.yaml
@@ -10457,41 +10457,22 @@
     const id = $("#notificationId").val().toString();
 
 
-    let details;
+    const itemId = Office.context.mailbox.item.itemId;
 
-    // Identifies whether the current mail item is in read or compose mode.
-
-    if (Office.context.mailbox.item.itemId != undefined) {
-      // Read mode.
-      details = {
-        type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-        message: "This is an insight notification with id = " + id,
-        icon: "icon1",
-        actions: [
-          {
-            actionText: "Open insight",
-            actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-            commandId: "PG.HelpCommand.Read",
-            contextData: { a: "aValue", b: "bValue" }
-          }
-        ]
-      };
-    } else {
-      // Compose mode.
-      details = {
-        type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-        message: "This is an insight notification with id = " + id,
-        icon: "icon1",
-        actions: [
-          {
-            actionText: "Open insight",
-            actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-            commandId: "PG.HelpCommand.Compose",
-            contextData: { a: "aValue", b: "bValue" }
-          }
-        ]
-      };
-    }
+    const details = {
+      type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
+      message: "This is an insight notification with id = " + id,
+      icon: "icon1",
+      actions: [
+        {
+          actionText: "Open insight",
+          actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
+          // Identify whether the current mail item is in read or compose mode to set the appropriate commandId value.
+          commandId: (itemId == undefined ? "PG.HelpCommand.Compose" : "PG.HelpCommand.Read"),
+          contextData: { a: "aValue", b: "bValue" }
+        }
+      ]
+    };
 
 
     Office.context.mailbox.item.notificationMessages.addAsync(id, details,
@@ -12716,41 +12697,22 @@
     const id = $("#notificationId").val().toString();
 
 
-    let details;
+    const itemId = Office.context.mailbox.item.itemId;
 
-    // Identifies whether the current mail item is in read or compose mode.
-
-    if (Office.context.mailbox.item.itemId != undefined) {
-      // Read mode.
-      details = {
-        type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-        message: "This is an insight notification with id = " + id,
-        icon: "icon1",
-        actions: [
-          {
-            actionText: "Open insight",
-            actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-            commandId: "PG.HelpCommand.Read",
-            contextData: { a: "aValue", b: "bValue" }
-          }
-        ]
-      };
-    } else {
-      // Compose mode.
-      details = {
-        type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
-        message: "This is an insight notification with id = " + id,
-        icon: "icon1",
-        actions: [
-          {
-            actionText: "Open insight",
-            actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
-            commandId: "PG.HelpCommand.Compose",
-            contextData: { a: "aValue", b: "bValue" }
-          }
-        ]
-      };
-    }
+    const details = {
+      type: Office.MailboxEnums.ItemNotificationMessageType.InsightMessage,
+      message: "This is an insight notification with id = " + id,
+      icon: "icon1",
+      actions: [
+        {
+          actionText: "Open insight",
+          actionType: Office.MailboxEnums.ActionType.ShowTaskPane,
+          // Identify whether the current mail item is in read or compose mode to set the appropriate commandId value.
+          commandId: (itemId == undefined ? "PG.HelpCommand.Compose" : "PG.HelpCommand.Read"),
+          contextData: { a: "aValue", b: "bValue" }
+        }
+      ]
+    };
 
 
     Office.context.mailbox.item.notificationMessages.addAsync(id, details,


### PR DESCRIPTION
Fixes the snippet that adds an insight notification to a mail item. The snippet now references command IDs available in the Script Lab manifest. This PR also cleans up the task pane UI to provide users with instructions on how to effectively run the snippet.