### PR TITLE
[All hosts] Update Office JS API and Fabric Core CDN URLs

### DIFF
--- a/config/build.ts
+++ b/config/build.ts
@@ -170,8 +170,8 @@ async function processSnippets(processedSnippets: Dictionary<SnippetProcessedDat
 
     function validateProperFabric(snippet: ISnippet): void {
         const libs = snippet.libraries.split('\n').map(reference => reference.trim());
-        if (libs.indexOf('office-ui-fabric-js@1.4.0/dist/css/fabric.min.css') >= 0) {
-            if (libs.indexOf('office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css') <= 0) {
+        if (libs.indexOf('office-ui-fabric-core@11.1.0/dist/css/fabric.min.css') >= 0) {
+            if (libs.indexOf('office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css') <= 0) {
                 throw new Error('Fabric reference is specified, without a reference to a corresponding "fabric.components.min.css". Please add this second Fabric reference as well.');
             }
         }
@@ -220,7 +220,7 @@ async function processSnippets(processedSnippets: Dictionary<SnippetProcessedDat
 
     function validateOfficialOfficeJs(snippet: ISnippet, host: string, group: string, messages: any[]): void {
         const isOfficeSnippet = officeHosts.indexOf(host.toUpperCase()) >= 0;
-        const canonicalOfficeJsReference = 'https://appsforoffice.microsoft.com/lib/1/hosted/office.js';
+        const canonicalOfficeJsReference = 'https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js';
         const betaOfficeJsReference = 'https://appsforoffice.microsoft.com/lib/beta/hosted/office.js';
         const officeDTS = '@types/office-js';
         const betaOfficeDTS = '@types/office-js-preview';
@@ -363,11 +363,12 @@ async function processSnippets(processedSnippets: Dictionary<SnippetProcessedDat
 
         const defaultSubstitutions = {
             'jquery': 'jquery@3.1.1',
-            'office-ui-fabric-js/dist/js/fabric.min.js': 'office-ui-fabric-js@1.4.0/dist/js/fabric.min.js',
+            'office-ui-fabric-js/dist/js/fabric.min.js': 'office-ui-fabric-js@1.5.0/dist/js/fabric.min.js',
             '@microsoft/office-js-helpers/dist/office.helpers.min.js': '@microsoft/office-js-helpers@0.7.4/dist/office.helpers.min.js',
             'core-js/client/core.min.js': 'core-js@2.4.1/client/core.min.js',
-            'office-ui-fabric-js/dist/css/fabric.min.css': 'office-ui-fabric-js@1.4.0/dist/css/fabric.min.css',
-            'office-ui-fabric-js/dist/css/fabric.components.min.css': 'office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css'
+            'office-ui-fabric-core/dist/css/fabric.min.css': 'office-ui-fabric-core@11.1.0/dist/css/fabric.min.css',
+            'office-ui-fabric-js/dist/css/fabric.min.css': 'office-ui-fabric-core@11.1.0/dist/css/fabric.min.css',
+            'office-ui-fabric-js/dist/css/fabric.components.min.css': 'office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css'
         };
 
         let hadDefaultSubstitution = false;

--- a/private-samples/excel/20-chart/chart-title-ts.yaml
+++ b/private-samples/excel/20-chart/chart-title-ts.yaml
@@ -130,11 +130,11 @@ style:
     language: css
 libraries: |
     // Office.js
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
 
     // CSS Libraries
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     // NPM libraries
     core-js@2.4.1/client/core.min.js

--- a/private-samples/excel/20-chart/chart-title-ts.yaml
+++ b/private-samples/excel/20-chart/chart-title-ts.yaml
@@ -94,18 +94,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set and get the title of a chart using the Excel JavaScript API.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create sample chart</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-title" class="ms-Button">
                 <span class="ms-Button-label">Set chart title</span>

--- a/samples/excel/01-basics/basic-api-call-es5.yaml
+++ b/samples/excel/01-basics/basic-api-call-es5.yaml
@@ -34,11 +34,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample demonstrates basic Excel API calls.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p class="ms-font-m">Select some cells in the worksheet, then press <b>Highlight selected range</b>.</p>
             <button id="run" class="ms-Button">

--- a/samples/excel/01-basics/basic-api-call-es5.yaml
+++ b/samples/excel/01-basics/basic-api-call-es5.yaml
@@ -60,11 +60,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/01-basics/basic-api-call.yaml
+++ b/samples/excel/01-basics/basic-api-call.yaml
@@ -61,11 +61,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/01-basics/basic-api-call.yaml
+++ b/samples/excel/01-basics/basic-api-call.yaml
@@ -35,11 +35,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample demonstrates basic Excel API calls.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p class="ms-font-m">Select some cells in the worksheet, then press <b>Highlight selected range</b>.</p>
             <button id="run" class="ms-Button">

--- a/samples/excel/01-basics/basic-common-api-call.yaml
+++ b/samples/excel/01-basics/basic-common-api-call.yaml
@@ -52,11 +52,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/01-basics/basic-common-api-call.yaml
+++ b/samples/excel/01-basics/basic-common-api-call.yaml
@@ -25,11 +25,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample uses the Common APIs compatible with Office 2013.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Select a cell in the worksheet and press <b>Write to console</b> to see the contents of that cell in the console.</p>
             <button id="run" class="ms-Button">

--- a/samples/excel/10-chart/chart-axis-formatting.yaml
+++ b/samples/excel/10-chart/chart-axis-formatting.yaml
@@ -157,11 +157,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-axis-formatting.yaml
+++ b/samples/excel/10-chart/chart-axis-formatting.yaml
@@ -119,25 +119,25 @@ script:
 template:
     content: |-
 
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to format the vertical and horizontal axis in a chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="format-horizontal-axis" class="ms-Button">
                 <span class="ms-Button-label">Format horizontal axis</span>
                 </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="format-vertical-axis" class="ms-Button">
                 <span class="ms-Button-label">Format vertical axis</span>
                 </button>

--- a/samples/excel/10-chart/chart-axis.yaml
+++ b/samples/excel/10-chart/chart-axis.yaml
@@ -170,43 +170,43 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get, set, and remove axis unit, label and title in a chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-axis-unit" class="ms-Button">
                 <span class="ms-Button-label">Get axis unit</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="change-axis-unit" class="ms-Button">
                 <span class="ms-Button-label">Change axis unit</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="remove-axis-label" class="ms-Button">
                 <span class="ms-Button-label">Remove axis label</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="show-axis-label" class="ms-Button">
                 <span class="ms-Button-label">Show axis label</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="set-axis-title" class="ms-Button">
                 <span class="ms-Button-label">Set axis title</span>
             </button>

--- a/samples/excel/10-chart/chart-axis.yaml
+++ b/samples/excel/10-chart/chart-axis.yaml
@@ -226,11 +226,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-bubble-chart.yaml
+++ b/samples/excel/10-chart/chart-bubble-chart.yaml
@@ -117,18 +117,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to create a bubble chart, with each chart series (or bubble) representing a single table row.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="create-bubble-chart" class="ms-Button">
                 <span class="ms-Button-label">Create a bubble chart</span>

--- a/samples/excel/10-chart/chart-bubble-chart.yaml
+++ b/samples/excel/10-chart/chart-bubble-chart.yaml
@@ -153,11 +153,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-create-several-charts.yaml
+++ b/samples/excel/10-chart/chart-create-several-charts.yaml
@@ -250,18 +250,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create column-clustered, line, XY-scatter, area, radar, pie, 3D, cylinder, and 100% charts.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="create-column-clustered-chart" class="ms-Button">
             <span class="ms-Button-label">Create a column clustered chart</span>

--- a/samples/excel/10-chart/chart-create-several-charts.yaml
+++ b/samples/excel/10-chart/chart-create-several-charts.yaml
@@ -322,11 +322,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-data-source.yaml
+++ b/samples/excel/10-chart/chart-data-source.yaml
@@ -114,11 +114,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-data-source.yaml
+++ b/samples/excel/10-chart/chart-data-source.yaml
@@ -81,11 +81,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get information about the data source of a chart series.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <p>Add a product table and line chart to a sample worksheet.</p>
           <button id="setup" class="ms-Button">
@@ -93,7 +93,7 @@ template:
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>Log information to the console about the data source of the chart series <strong>Frames</strong>.</p>
           <button id="log-chart-series-source" class="ms-Button">

--- a/samples/excel/10-chart/chart-data-table.yaml
+++ b/samples/excel/10-chart/chart-data-table.yaml
@@ -153,10 +153,10 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
     core-js@2.4.1/client/core.min.js
     @types/core-js
     jquery@3.1.1

--- a/samples/excel/10-chart/chart-data-table.yaml
+++ b/samples/excel/10-chart/chart-data-table.yaml
@@ -114,11 +114,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to add a data table to a chart and then format that data table.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Create table</span>
@@ -129,7 +129,7 @@ template:
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="add-chart-data-table" class="ms-Button">
             <span class="ms-Button-label">Add chart data table</span>

--- a/samples/excel/10-chart/chart-formatting.yaml
+++ b/samples/excel/10-chart/chart-formatting.yaml
@@ -171,18 +171,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to format different aspects of a chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
                 <button id="setup" class="ms-Button">
                     <span class="ms-Button-label">Add sample data</span>
                 </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
                 <button id="format-chart" class="ms-Button">
                     <span class="ms-Button-label">Format chart</span>

--- a/samples/excel/10-chart/chart-formatting.yaml
+++ b/samples/excel/10-chart/chart-formatting.yaml
@@ -212,11 +212,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-legend.yaml
+++ b/samples/excel/10-chart/chart-legend.yaml
@@ -100,18 +100,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to format the legend font in a chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="format-legend-font" class="ms-Button">
                 <span class="ms-Button-label">Format legend font</span>

--- a/samples/excel/10-chart/chart-legend.yaml
+++ b/samples/excel/10-chart/chart-legend.yaml
@@ -132,11 +132,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-point.yaml
+++ b/samples/excel/10-chart/chart-point.yaml
@@ -118,11 +118,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-point.yaml
+++ b/samples/excel/10-chart/chart-point.yaml
@@ -85,18 +85,18 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set chart point color.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-chart-point-color" class="ms-Button">
                 <span class="ms-Button-label">Set chart point color</span>

--- a/samples/excel/10-chart/chart-series-markers.yaml
+++ b/samples/excel/10-chart/chart-series-markers.yaml
@@ -113,11 +113,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-series-markers.yaml
+++ b/samples/excel/10-chart/chart-series-markers.yaml
@@ -81,18 +81,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set chart series marker properties.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-markers" class="ms-Button">
                 <span class="ms-Button-label">Set marker properties</span>

--- a/samples/excel/10-chart/chart-series-plotorder.yaml
+++ b/samples/excel/10-chart/chart-series-plotorder.yaml
@@ -92,18 +92,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to change the plot order of series in a chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="order-series-plot" class="ms-Button">
                 <span class="ms-Button-label">Order series plot</span>

--- a/samples/excel/10-chart/chart-series-plotorder.yaml
+++ b/samples/excel/10-chart/chart-series-plotorder.yaml
@@ -124,11 +124,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-series.yaml
+++ b/samples/excel/10-chart/chart-series.yaml
@@ -141,11 +141,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-series.yaml
+++ b/samples/excel/10-chart/chart-series.yaml
@@ -103,25 +103,25 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add and delete a series in a chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-series" class="ms-Button">
                 <span class="ms-Button-label">Add series</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="delete-series" class="ms-Button">
                 <span class="ms-Button-label">Delete series</span>
             </button>

--- a/samples/excel/10-chart/chart-title-format.yaml
+++ b/samples/excel/10-chart/chart-title-format.yaml
@@ -149,11 +149,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/chart-title-format.yaml
+++ b/samples/excel/10-chart/chart-title-format.yaml
@@ -107,18 +107,18 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to adjust format a chart's title.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="change-title-format" class="ms-Button">
                 <span class="ms-Button-label">Change title format</span>

--- a/samples/excel/10-chart/chart-trendlines.yaml
+++ b/samples/excel/10-chart/chart-trendlines.yaml
@@ -140,36 +140,36 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, get, and format trendlines in a chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-trendline" class="ms-Button">
                 <span class="ms-Button-label">Add trendline</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="get-trendline" class="ms-Button">
                 <span class="ms-Button-label">Get trendline</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="get-trendline-color" class="ms-Button">
                 <span class="ms-Button-label">Get trendline color</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="set-trendline-color" class="ms-Button">
                 <span class="ms-Button-label">Set trendline color</span>
             </button>

--- a/samples/excel/10-chart/chart-trendlines.yaml
+++ b/samples/excel/10-chart/chart-trendlines.yaml
@@ -189,11 +189,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/create-doughnut-chart.yaml
+++ b/samples/excel/10-chart/create-doughnut-chart.yaml
@@ -139,11 +139,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/10-chart/create-doughnut-chart.yaml
+++ b/samples/excel/10-chart/create-doughnut-chart.yaml
@@ -103,18 +103,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create a doughnut chart.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="create-doughnut-chart" class="ms-Button">
                 <span class="ms-Button-label">Create a doughnut chart</span>

--- a/samples/excel/12-comment/comment-basics.yaml
+++ b/samples/excel/12-comment/comment-basics.yaml
@@ -83,16 +83,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, edit, and remove comments.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>To better view the comment changes, open the Comments pane by selecting <b>Show Comments</b> from the <b>Review</b> tab.</p>
             <button id="add-comment-to-selected-cell" class="ms-Button">

--- a/samples/excel/12-comment/comment-basics.yaml
+++ b/samples/excel/12-comment/comment-basics.yaml
@@ -130,11 +130,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/12-comment/comment-mentions.yaml
+++ b/samples/excel/12-comment/comment-mentions.yaml
@@ -89,11 +89,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/12-comment/comment-mentions.yaml
+++ b/samples/excel/12-comment/comment-mentions.yaml
@@ -54,17 +54,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to mention someone in a comment.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <p><b>IMPORTANT</b>: This sample is currently only supported by Excel on the web.</p>
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>To better view the comment changes, open the Comments pane by selecting <b>Show Comments</b> from the <b>Review</b> tab.</p>
           <p />

--- a/samples/excel/12-comment/comment-replies.yaml
+++ b/samples/excel/12-comment/comment-replies.yaml
@@ -151,11 +151,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/12-comment/comment-replies.yaml
+++ b/samples/excel/12-comment/comment-replies.yaml
@@ -103,16 +103,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to add, edit, and remove comment replies.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>To better view the comment changes, open the Comments pane by selecting <b>Show Comments</b> from the <b>Review</b> tab.</p>
           <button id="add-first-comment-reply" class="ms-Button">

--- a/samples/excel/12-comment/comment-resolution.yaml
+++ b/samples/excel/12-comment/comment-resolution.yaml
@@ -60,16 +60,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to resolve and reopen comment threads.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>To better view the comment changes, open the Comments pane by selecting <b>Show Comments</b> from the <b>Review</b> tab.</p>
             <p />

--- a/samples/excel/12-comment/comment-resolution.yaml
+++ b/samples/excel/12-comment/comment-resolution.yaml
@@ -100,11 +100,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/14-conditional-formatting/conditional-formatting-advanced.yaml
+++ b/samples/excel/14-conditional-formatting/conditional-formatting-advanced.yaml
@@ -179,19 +179,19 @@ script:
     language: typescript
 template:
     content: |
-        <section id="main" class="ms-font-m">
+        <section id="main" class="ms-Fabric ms-font-m">
             <p>This sample shows how to use priorities to work with conditional formatting of ranges when more than one conditional format
                 applies to some cells.</p>
         </section>
 
-        <section id="main" class="setup ms-font-m">
+        <section id="main" class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section id="main" class="samples ms-font-m">
+        <section id="main" class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <label class="ms-font-s">Apply two conditional formats which both affect negative numbers (among others) and assign conflicting font colors. The color specified by the format that is applied first will take effect. Negative numbers will be bold red with a green background.</label>
             <button id="apply-conditional-formats-default-priority" class="ms-Button">

--- a/samples/excel/14-conditional-formatting/conditional-formatting-advanced.yaml
+++ b/samples/excel/14-conditional-formatting/conditional-formatting-advanced.yaml
@@ -225,11 +225,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/14-conditional-formatting/conditional-formatting-basic.yaml
+++ b/samples/excel/14-conditional-formatting/conditional-formatting-basic.yaml
@@ -342,11 +342,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/14-conditional-formatting/conditional-formatting-basic.yaml
+++ b/samples/excel/14-conditional-formatting/conditional-formatting-basic.yaml
@@ -274,18 +274,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section id="main" class="ms-font-m">
+        <section id="main" class="ms-Fabric ms-font-m">
             <p>This sample shows how to apply conditional formatting to ranges.</p>
         </section>
 
-        <section id="main" class="setup ms-font-m">
+        <section id="main" class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section id="main" class="samples ms-font-m">
+        <section id="main" class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <label class="ms-font-s">Add color scale to temperature table.</label>
             <button id="apply-color-scale-format" class="ms-Button">

--- a/samples/excel/16-custom-functions/basic-function.yaml
+++ b/samples/excel/16-custom-functions/basic-function.yaml
@@ -18,6 +18,6 @@ script:
         }
     language: typescript
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
     core-js@2.4.1/client/core.min.js

--- a/samples/excel/16-custom-functions/custom-functions-errors.yaml
+++ b/samples/excel/16-custom-functions/custom-functions-errors.yaml
@@ -33,6 +33,6 @@ script:
         }
     language: typescript
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
     core-js@2.4.1/client/core.min.js

--- a/samples/excel/16-custom-functions/data-types-custom-functions.yaml
+++ b/samples/excel/16-custom-functions/data-types-custom-functions.yaml
@@ -327,7 +327,7 @@ script:
         ];
     language: typescript
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
     core-js@2.4.1/client/core.min.js

--- a/samples/excel/16-custom-functions/streaming-function.yaml
+++ b/samples/excel/16-custom-functions/streaming-function.yaml
@@ -28,6 +28,6 @@ script:
         }
     language: typescript
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
     core-js@2.4.1/client/core.min.js

--- a/samples/excel/16-custom-functions/volatile-function.yaml
+++ b/samples/excel/16-custom-functions/volatile-function.yaml
@@ -17,6 +17,6 @@ script:
         }
     language: typescript
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
     core-js@2.4.1/client/core.min.js

--- a/samples/excel/16-custom-functions/web-call-function.yaml
+++ b/samples/excel/16-custom-functions/web-call-function.yaml
@@ -28,6 +28,6 @@ script:
         }
     language: typescript
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
     core-js@2.4.1/client/core.min.js

--- a/samples/excel/18-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
+++ b/samples/excel/18-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
@@ -104,11 +104,11 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create, set, get, and delete custom XML parts in the file.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Press the button to create and display Contoso's Reviewer metadata.</p>
             <button id="create-custom-xml-part" class="ms-Button">
@@ -125,7 +125,7 @@ template:
         </section>
 
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>XML part display</h3>
             <div id="display-xml" class="ms-font-l" style="max-width:320px;">
             </div>

--- a/samples/excel/18-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
+++ b/samples/excel/18-custom-xml-parts/create-set-get-and-delete-custom-xml-parts.yaml
@@ -146,11 +146,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/18-custom-xml-parts/test-xml-for-unique-namespace.yaml
+++ b/samples/excel/18-custom-xml-parts/test-xml-for-unique-namespace.yaml
@@ -91,11 +91,11 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to determine if there is just one XML part for a specified namespace.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Press the "Create XML part" button to create and display Contoso's Reviewer metadata. <span class="ms-fontWeight-semibold">Press it more than once if you want to set up an error situation.</span></p>
             <button id="create-custom-xml-part" class="ms-Button">
@@ -111,7 +111,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>XML part display</h3>
             <div id="display-xml" class="ms-font-l" style="max-width:320px;">
             </div>

--- a/samples/excel/18-custom-xml-parts/test-xml-for-unique-namespace.yaml
+++ b/samples/excel/18-custom-xml-parts/test-xml-for-unique-namespace.yaml
@@ -132,11 +132,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/20-data-types/data-types-entity-attribution.yaml
+++ b/samples/excel/20-data-types/data-types-entity-attribution.yaml
@@ -221,11 +221,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/20-data-types/data-types-entity-attribution.yaml
+++ b/samples/excel/20-data-types/data-types-entity-attribution.yaml
@@ -189,16 +189,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to set data provider attributions on entity values in the card layout. The data is aggregated from three different data providers, and three attributions are displayed.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Create table</span>
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="add-entities-to-table" class="ms-Button">
             <span class="ms-Button-label">Add entity values</span>

--- a/samples/excel/20-data-types/data-types-entity-icons.yaml
+++ b/samples/excel/20-data-types/data-types-entity-icons.yaml
@@ -76,17 +76,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to display all the icons available for entity data types, along with the name of each icon.</p>
           <p>After creating the icons, select an icon to open the entity card for that data type. The entity cards in this sample display only the icon names.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Set up</span>
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Run sample</h3>
           <button id="create-icons" class="ms-Button">
             <span class="ms-Button-label">Create icons</span> 

--- a/samples/excel/20-data-types/data-types-entity-icons.yaml
+++ b/samples/excel/20-data-types/data-types-entity-icons.yaml
@@ -107,11 +107,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/20-data-types/data-types-entity-values.yaml
+++ b/samples/excel/20-data-types/data-types-entity-values.yaml
@@ -568,17 +568,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to create entity values for each row in a table. An entity value is a container for data types, similar to an object in object-oriented programming.</p>
           <p>In particular, this sample highlights the card layout options of an entity value, including the title, an image, collapsible sections, and nested entity values.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Create table</span>
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="addEntitiesToTable" class="ms-Button">
             <span class="ms-Button-label">Add entity values</span>

--- a/samples/excel/20-data-types/data-types-entity-values.yaml
+++ b/samples/excel/20-data-types/data-types-entity-values.yaml
@@ -601,11 +601,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -75,10 +75,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to set the value of cell A1 to the #BUSY! error data type. The sample then checks to see if the worksheet contains a #BUSY! error, and then updates all cells that contain a #BUSY! error.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add worksheet</span>

--- a/samples/excel/20-data-types/data-types-error-values.yaml
+++ b/samples/excel/20-data-types/data-types-error-values.yaml
@@ -106,11 +106,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/20-data-types/data-types-formatted-number.yaml
+++ b/samples/excel/20-data-types/data-types-formatted-number.yaml
@@ -110,10 +110,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to work with the formatted number data type.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add worksheet</span>

--- a/samples/excel/20-data-types/data-types-formatted-number.yaml
+++ b/samples/excel/20-data-types/data-types-formatted-number.yaml
@@ -144,11 +144,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/20-data-types/data-types-references.yaml
+++ b/samples/excel/20-data-types/data-types-references.yaml
@@ -332,11 +332,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/20-data-types/data-types-references.yaml
+++ b/samples/excel/20-data-types/data-types-references.yaml
@@ -293,16 +293,16 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to create entity values with references to other entity values. An entity value is a container for data, and this container can reference (or contain) other entities within the original entity. One entity can contain multiple additional entities.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Create table</span>
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>To see referenced entities within an entity, take the following steps.</p>
           <ol>

--- a/samples/excel/20-data-types/data-types-web-image.yaml
+++ b/samples/excel/20-data-types/data-types-web-image.yaml
@@ -121,12 +121,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to work with the web image data type. Insert an image into the selected cell and then
             retrieve information about that image.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <p>Add a new worksheet and then enter the URL and alt text for an image of your choice.</p>
           <button id="setup" class="ms-Button">
@@ -138,7 +138,7 @@ template:
           <input type="text" name="alt-text" id="alt-text" alt="Alt text input field">
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>Select the cell you want to insert the web image into, and then select the <strong>Insert image</strong> button.</p>
           <button id="insert-image" class="ms-Button">

--- a/samples/excel/20-data-types/data-types-web-image.yaml
+++ b/samples/excel/20-data-types/data-types-web-image.yaml
@@ -187,11 +187,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/22-data-validation/data-validation.yaml
+++ b/samples/excel/22-data-validation/data-validation.yaml
@@ -179,11 +179,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/22-data-validation/data-validation.yaml
+++ b/samples/excel/22-data-validation/data-validation.yaml
@@ -138,18 +138,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to apply data validation to cells.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
                 <button id="setup" class="ms-Button">
                     <span class="ms-Button-label">Add table</span>
                 </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
                 <p class="ms-font-m">Press <b>Require approved name</b> and then click on a cell in the <b>Baby Name</b> column and use the drop down to enter an approved value.</p>
                 <button id="require-approved-location" class="ms-Button">

--- a/samples/excel/26-document/custom-properties.yaml
+++ b/samples/excel/26-document/custom-properties.yaml
@@ -90,11 +90,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to set and get custom properties at both the document level and the worksheet level.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <p>Enter the key/value pairs for your custom properties.</p>
           <p><b>Key:</b> <textarea id="key">MyKey</textarea></p>
           <p><b>Value:</b> <textarea id="value">MyValue</textarea></p>

--- a/samples/excel/26-document/custom-properties.yaml
+++ b/samples/excel/26-document/custom-properties.yaml
@@ -131,11 +131,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/26-document/get-file-in-slices-async.yaml
+++ b/samples/excel/26-document/get-file-in-slices-async.yaml
@@ -203,11 +203,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/26-document/get-file-in-slices-async.yaml
+++ b/samples/excel/26-document/get-file-in-slices-async.yaml
@@ -154,18 +154,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the Base64-encoded string that represents the current document. It uses the getFileAsync() method to read the file in slices and then joins all slices back together to form the complete file.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>   
             <button id="get-file" class="ms-Button">
                 <span class="ms-Button-label">Get file</span>
@@ -175,7 +175,7 @@ template:
             </textarea>    
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Create a new workbook</h3>
             <button id="new-workbook-from-file" class="ms-Button">
                 <span class="ms-Button-label">Create workbook from string</span>

--- a/samples/excel/26-document/properties.yaml
+++ b/samples/excel/26-document/properties.yaml
@@ -174,11 +174,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/26-document/properties.yaml
+++ b/samples/excel/26-document/properties.yaml
@@ -124,36 +124,36 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set and get document properties.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-doc-properties" class="ms-Button">
                 <span class="ms-Button-label">Set document properties</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="get-doc-properties" class="ms-Button">
                 <span class="ms-Button-label">Get document properties</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="set-custom-doc-properties" class="ms-Button">
                 <span class="ms-Button-label">Set custom document properties</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="get-custom-doc-properties" class="ms-Button">
                 <span class="ms-Button-label">Get custom document properties</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="get-count-custom-doc-properties" class="ms-Button">
                 <span class="ms-Button-label">Get count of custom document properties</span>
             </button>

--- a/samples/excel/30-events/data-change-event-details.yaml
+++ b/samples/excel/30-events/data-change-event-details.yaml
@@ -103,11 +103,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/data-change-event-details.yaml
+++ b/samples/excel/30-events/data-change-event-details.yaml
@@ -70,17 +70,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to use table changed events.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="register-handler" class="ms-Button">
                 <span class="ms-Button-label">Register data change handler</span>

--- a/samples/excel/30-events/data-changed.yaml
+++ b/samples/excel/30-events/data-changed.yaml
@@ -107,11 +107,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/data-changed.yaml
+++ b/samples/excel/30-events/data-changed.yaml
@@ -75,18 +75,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use a handler for the data-changed event.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="register-data-changed-handler" class="ms-Button">
                 <span class="ms-Button-label">Register data-changed handler</span>

--- a/samples/excel/30-events/event-column-and-row-sort.yaml
+++ b/samples/excel/30-events/event-column-and-row-sort.yaml
@@ -195,11 +195,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/event-column-and-row-sort.yaml
+++ b/samples/excel/30-events/event-column-and-row-sort.yaml
@@ -150,18 +150,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to register and use handlers for the column and row sorting events.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample data</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="register-sort-handlers" class="ms-Button">
               <span class="ms-Button-label">Register event handlers</span>

--- a/samples/excel/30-events/event-worksheet-single-click.yaml
+++ b/samples/excel/30-events/event-worksheet-single-click.yaml
@@ -37,11 +37,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to register and use a handler for the single-click event.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>Use the button below to register the event handler. Then, left-click around the worksheet and check the console.
           </p>

--- a/samples/excel/30-events/event-worksheet-single-click.yaml
+++ b/samples/excel/30-events/event-worksheet-single-click.yaml
@@ -64,11 +64,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-chart-activated.yaml
+++ b/samples/excel/30-events/events-chart-activated.yaml
@@ -169,11 +169,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-chart-activated.yaml
+++ b/samples/excel/30-events/events-chart-activated.yaml
@@ -136,18 +136,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use handlers for the Chart onActivated and onDeactivated events.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Click the button to register handlers for the pie chart's activated and deactivated events. Then click the chart to activate it. Watch the console. Finally, click the cylinder chart to deactivate the pie chart.</p>
             <button id="register-onactivated-deactivated-handlers" class="ms-Button">

--- a/samples/excel/30-events/events-chartcollection-added-activated.yaml
+++ b/samples/excel/30-events/events-chartcollection-added-activated.yaml
@@ -110,18 +110,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use handlers for the ChartCollection onAdded, onDeleted, onActivated, and onDeactivated events.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Click the button to register and use handlers for the worksheet's ChartCollection events. </p>
             <button id="register-chartcollection-handlers" class="ms-Button">

--- a/samples/excel/30-events/events-chartcollection-added-activated.yaml
+++ b/samples/excel/30-events/events-chartcollection-added-activated.yaml
@@ -150,11 +150,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-comment-event-handler.yaml
+++ b/samples/excel/30-events/events-comment-event-handler.yaml
@@ -168,11 +168,11 @@ style:
         }
         language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-comment-event-handler.yaml
+++ b/samples/excel/30-events/events-comment-event-handler.yaml
@@ -125,10 +125,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register event handlers to listen for comment additions, changes, and deletions.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
@@ -138,7 +138,7 @@ template:
                 <span class="ms-Button-label">Register event handlers</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>In addition to hovering over a cell, you can view comment changes in the Comments pane by selecting <b>Show Comments</b> from the <b>Review</b> tab.</p>
             <button id="add-comment" class="ms-Button">

--- a/samples/excel/30-events/events-disable-events.yaml
+++ b/samples/excel/30-events/events-disable-events.yaml
@@ -136,10 +136,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to turn events on and off.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create random numbers</span>
@@ -148,7 +148,7 @@ template:
                 <span class="ms-Button-label">Register event handlers on sums</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>The handlers update the "Grand Total" cell when events are fired (and enabled). Try editing the cells or refreshing the data with events enabled and disabled.</p>
             <button id="toggleEvents" class="ms-Button">

--- a/samples/excel/30-events/events-disable-events.yaml
+++ b/samples/excel/30-events/events-disable-events.yaml
@@ -174,11 +174,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-formula-changed.yaml
+++ b/samples/excel/30-events/events-formula-changed.yaml
@@ -85,10 +85,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to register a formula changed event handler and detect details about the changed formula.</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p class="ms-font-m">Set up the worksheet.</p>
             <button id="setup" class="ms-Button">

--- a/samples/excel/30-events/events-formula-changed.yaml
+++ b/samples/excel/30-events/events-formula-changed.yaml
@@ -118,11 +118,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-table-changed.yaml
+++ b/samples/excel/30-events/events-table-changed.yaml
@@ -110,38 +110,38 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use event handlers for table onChanged and onSelectionChanged events.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="register-on-changed-handler" class="ms-Button">
                 <span class="ms-Button-label">Register onChanged event handler</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p>Changing data in a table triggers the data changed event. You can change the data manually or programmatically.</p>
             <button id="change-data" class="ms-Button">
                 <span class="ms-Button-label">Change data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="register-on-selection-changed-handler" class="ms-Button">
                 <span class="ms-Button-label">Register onSelectionChanged event handler</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
                 <p>Changing a range selection in a table triggers the table onSelectionChanged event. You can change selection manually or programmatically.</p>
             <button id="change-selection" class="ms-Button">
                 <span class="ms-Button-label">Change range selection</span>

--- a/samples/excel/30-events/events-table-changed.yaml
+++ b/samples/excel/30-events/events-table-changed.yaml
@@ -164,11 +164,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-tablecollection-changed.yaml
+++ b/samples/excel/30-events/events-tablecollection-changed.yaml
@@ -157,11 +157,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-tablecollection-changed.yaml
+++ b/samples/excel/30-events/events-tablecollection-changed.yaml
@@ -117,25 +117,25 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use an event handler for table collection onChanged event.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="register-on-changed-handler" class="ms-Button">
                 <span class="ms-Button-label">Register onChanged event handler</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p>Changing data in tables triggers the data changed event. You can change the data manually or programmatically.</p>
             <button id="change-data" class="ms-Button">
                 <span class="ms-Button-label">Change data</span>

--- a/samples/excel/30-events/events-workbook-activated.yaml
+++ b/samples/excel/30-events/events-workbook-activated.yaml
@@ -67,11 +67,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-workbook-activated.yaml
+++ b/samples/excel/30-events/events-workbook-activated.yaml
@@ -40,13 +40,13 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to register a workbook activated event handler.</p>
           <p>Once the event handler is registered, a notification prints to the console when the workbook is activated. Try
             switching to another application and then switching back to Excel to see the console notification.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Try it out</h3>
           <button id="register-event-handler" class="ms-Button">
               <span class="ms-Button-label">Register the event handler</span>

--- a/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+++ b/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
@@ -225,11 +225,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+++ b/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
@@ -171,15 +171,15 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use handlers for when a worksheet is added, activated, or deactivated, or when the settings of a workbook are changed.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
 
             <p><b>Added</b></p>
-            <section class="samples ms-font-m">
+            <section class="ms-Fabric samples ms-font-m">
                 <button id="register-on-add-handler" class="ms-Button">
                     <span class="ms-Button-label">Register onAdded event handler</span>
                 </button>

--- a/samples/excel/30-events/events-worksheet-protection.yaml
+++ b/samples/excel/30-events/events-worksheet-protection.yaml
@@ -98,11 +98,11 @@ style:
         }
         language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-worksheet-protection.yaml
+++ b/samples/excel/30-events/events-worksheet-protection.yaml
@@ -69,10 +69,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register a worksheet protection change event handler. Once the event handler is registered, you can enable and disable worksheet protection for the current worksheet. When worksheet protection is enabled, the current worksheet can't be edited.</p>
         </section>
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <h3>Try it out</h3>
             <button id="register-event" class="ms-Button">
                 <span class="ms-Button-label">Register worksheet protection event</span>

--- a/samples/excel/30-events/events-worksheet.yaml
+++ b/samples/excel/30-events/events-worksheet.yaml
@@ -221,11 +221,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/30-events/events-worksheet.yaml
+++ b/samples/excel/30-events/events-worksheet.yaml
@@ -169,21 +169,21 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use an event handler for the worksheet onSelectionChanged event.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample data</span>
         </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
 
-            <p><b>Selection Changed</b></p><section class="samples ms-font-m">
+            <p><b>Selection Changed</b></p><section class="ms-Fabric samples ms-font-m">
             <button id="register-on-selection-changed-handler" class="ms-Button">
                 <span class="ms-Button-label">Register onSelectionChanged handler</span>
             </button>

--- a/samples/excel/30-events/selection-changed-events.yaml
+++ b/samples/excel/30-events/selection-changed-events.yaml
@@ -102,11 +102,11 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to register and use event handlers for table <code>onChanged</code> and <code>onSelectionChanged</code> events.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
@@ -123,11 +123,11 @@ template:
             </ul>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p>The console will log the addresses reported by the different <code>onSelectionChanged</code> events. Change the cell or cells selected in the worksheet to see the results. Try selecting single cells, multiple cells, and multiple discontiguous cells.</p>
         </section>
 

--- a/samples/excel/30-events/selection-changed-events.yaml
+++ b/samples/excel/30-events/selection-changed-events.yaml
@@ -147,11 +147,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/34-named-item/create-and-remove-named-item.yaml
+++ b/samples/excel/34-named-item/create-and-remove-named-item.yaml
@@ -225,11 +225,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/34-named-item/create-and-remove-named-item.yaml
+++ b/samples/excel/34-named-item/create-and-remove-named-item.yaml
@@ -183,11 +183,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create, access, and delete named items.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>

--- a/samples/excel/34-named-item/update-named-item.yaml
+++ b/samples/excel/34-named-item/update-named-item.yaml
@@ -123,11 +123,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/34-named-item/update-named-item.yaml
+++ b/samples/excel/34-named-item/update-named-item.yaml
@@ -91,11 +91,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create and update a named item.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>

--- a/samples/excel/38-pivottable/pivottable-calculations.yaml
+++ b/samples/excel/38-pivottable/pivottable-calculations.yaml
@@ -200,11 +200,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-calculations.yaml
+++ b/samples/excel/38-pivottable/pivottable-calculations.yaml
@@ -156,18 +156,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to change the calculations of PivotTable data hierarchies.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup sample</span>
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Try it out</h3>
             <button id="showPercentages" class="ms-Button">
                 <span class="ms-Button-label">Show percentages</span>
@@ -180,7 +180,7 @@ template:
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Clean up</h3>
             <button id="deletePivot" class="ms-Button">
                 <span class="ms-Button-label">Delete PivotTable</span>

--- a/samples/excel/38-pivottable/pivottable-create-and-modify.yaml
+++ b/samples/excel/38-pivottable/pivottable-create-and-modify.yaml
@@ -265,11 +265,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-create-and-modify.yaml
+++ b/samples/excel/38-pivottable/pivottable-create-and-modify.yaml
@@ -195,27 +195,27 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create PivotTables and add hierarchies to form rows, columns, and data sets.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup sample</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p><b>Create the PivotTable</b></p>
             <button id="createWithNames" class="ms-Button">
                 <span class="ms-Button-label">Create</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p><b>Adjust the PivotTable</b></p>
             <button id="addRow" class="ms-Button">
                 <span class="ms-Button-label">Add row</span>
@@ -234,7 +234,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p><b>Adjust formatting</b></p>
             <button id="changeHierarchyNames" class="ms-Button">
                 <span class="ms-Button-label">Change pivot hierarchy names</span>
@@ -245,7 +245,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p><b>Delete the PivotTable</b></p>
             <button id="deletePivot" class="ms-Button">
                 <span class="ms-Button-label">Delete PivotTable</span>

--- a/samples/excel/38-pivottable/pivottable-filters-and-summaries.yaml
+++ b/samples/excel/38-pivottable/pivottable-filters-and-summaries.yaml
@@ -222,11 +222,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-filters-and-summaries.yaml
+++ b/samples/excel/38-pivottable/pivottable-filters-and-summaries.yaml
@@ -154,22 +154,22 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to filter PivotTables and manipulate their data.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup sample</span>
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Try it out</h3>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <p><b>Change functions</b></p>
             <button id="minFunc" class="ms-Button">
                 <span class="ms-Button-label">Switch to minimums</span>
@@ -188,21 +188,21 @@ template:
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <p><b>Filtering</b></p>
             <button id="filter" class="ms-Button">
                 <span class="ms-Button-label">Enable filter</span>
             </button><p />
             <span>After pressing the "Enable filter" button, manually select the classification filter for the PivotTable</span>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <p><b>Data Manipulation</b></p>
             <button id="getCrateTotal" class="ms-Button">
                 <span class="ms-Button-label">Get or refresh crate total</span>
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Clean up</h3>
             <button id="deletePivot" class="ms-Button">
                 <span class="ms-Button-label">Delete PivotTable</span>

--- a/samples/excel/38-pivottable/pivottable-get-pivottables.yaml
+++ b/samples/excel/38-pivottable/pivottable-get-pivottables.yaml
@@ -186,11 +186,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-get-pivottables.yaml
+++ b/samples/excel/38-pivottable/pivottable-get-pivottables.yaml
@@ -139,12 +139,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get PivotTables in the workbook. You can get them through PivotTableCollection objects
             or by querying a Range object containing PivotTable data.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <p> This creates a data sheet and two PivotTables in two different worksheets.
             <button id="setup" class="ms-Button">
@@ -152,11 +152,11 @@ template:
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Try it out</h3>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <button id="get-pivottables-in-workbook" class="ms-Button">
             <span class="ms-Button-label">Get PivotTables in the workbook</span>
           </button>

--- a/samples/excel/38-pivottable/pivottable-pivotfilters.yaml
+++ b/samples/excel/38-pivottable/pivottable-pivotfilters.yaml
@@ -253,22 +253,22 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to filter PivotTables with the different PivotFilters.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup sample</span>
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Try it out</h3>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <p><b>Filters</b></p>
           <p><i>Manual filter</i></p>
           <button id="manual-filter" class="ms-Button">

--- a/samples/excel/38-pivottable/pivottable-pivotfilters.yaml
+++ b/samples/excel/38-pivottable/pivottable-pivotfilters.yaml
@@ -315,11 +315,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-pivotlayout.yaml
+++ b/samples/excel/38-pivottable/pivottable-pivotlayout.yaml
@@ -310,11 +310,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-pivotlayout.yaml
+++ b/samples/excel/38-pivottable/pivottable-pivotlayout.yaml
@@ -249,17 +249,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to work with the PivotLayout class to display the PivotTable.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup sample</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="change-layout" class="ms-Button">
               <span class="ms-Button-label">Change layout type</span>

--- a/samples/excel/38-pivottable/pivottable-refresh.yaml
+++ b/samples/excel/38-pivottable/pivottable-refresh.yaml
@@ -127,11 +127,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-refresh.yaml
+++ b/samples/excel/38-pivottable/pivottable-refresh.yaml
@@ -91,17 +91,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to refresh a PivotTable.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add data and PivotTable</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>Add a row to the table, then refresh the PivotTable. Note that the PivotTable doesn't automatically refresh.</p>
           <button id="add-table-row" class="ms-Button">

--- a/samples/excel/38-pivottable/pivottable-slicer.yaml
+++ b/samples/excel/38-pivottable/pivottable-slicer.yaml
@@ -201,11 +201,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/38-pivottable/pivottable-slicer.yaml
+++ b/samples/excel/38-pivottable/pivottable-slicer.yaml
@@ -142,11 +142,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to work with a slicer on a PivotTable.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add data</span>
@@ -156,7 +156,7 @@ template:
             <span class="ms-Button-label">Add PivotTable</span>
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>  
           <p>Add the slicer, then try out the formatting and filtering options.</p>
           <button id="add-slicer" class="ms-Button">

--- a/samples/excel/38-pivottable/pivottable-source-data.yaml
+++ b/samples/excel/38-pivottable/pivottable-source-data.yaml
@@ -89,19 +89,19 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get information about the data source of a PivotTable. It returns the type and string representation of the data source.</p>
           <p><em>Note: This sample works in Excel on Windows and Excel on the web. It doesn't work in Excel on Mac; this is a known issue.</em></p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Set up</span>
           </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Try it out</h3>
           <button id="get-pivottable-data-source" class="ms-Button">
             <span class="ms-Button-label">Get PivotTable data source</span>

--- a/samples/excel/38-pivottable/pivottable-source-data.yaml
+++ b/samples/excel/38-pivottable/pivottable-source-data.yaml
@@ -122,11 +122,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/cell-properties.yaml
+++ b/samples/excel/42-range/cell-properties.yaml
@@ -181,11 +181,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/cell-properties.yaml
+++ b/samples/excel/42-range/cell-properties.yaml
@@ -145,18 +145,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to format a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="set-cell-properties" class="ms-Button">
                 <span class="ms-Button-label">Set cell properties</span>

--- a/samples/excel/42-range/dynamic-arrays.yaml
+++ b/samples/excel/42-range/dynamic-arrays.yaml
@@ -129,19 +129,19 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to apply formulas that return dynamic arrays and how to get the relevant information
             about range spilling from the used ranges.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="copy-table-headers" class="ms-Button">
                   <span class="ms-Button-label">Copy table headers</span>

--- a/samples/excel/42-range/dynamic-arrays.yaml
+++ b/samples/excel/42-range/dynamic-arrays.yaml
@@ -172,11 +172,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/formatting.yaml
+++ b/samples/excel/42-range/formatting.yaml
@@ -76,18 +76,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to format a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-font-and-fill-color" class="ms-Button">
                 <span class="ms-Button-label">Set font and fill color</span>

--- a/samples/excel/42-range/formatting.yaml
+++ b/samples/excel/42-range/formatting.yaml
@@ -111,11 +111,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/insert-delete-clear-range.yaml
+++ b/samples/excel/42-range/insert-delete-clear-range.yaml
@@ -86,18 +86,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to insert, delete and clear the contents of a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="insert-range" class="ms-Button">
                 <span class="ms-Button-label">Insert range</span>

--- a/samples/excel/42-range/insert-delete-clear-range.yaml
+++ b/samples/excel/42-range/insert-delete-clear-range.yaml
@@ -124,11 +124,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/outline.yaml
+++ b/samples/excel/42-range/outline.yaml
@@ -227,11 +227,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/outline.yaml
+++ b/samples/excel/42-range/outline.yaml
@@ -171,11 +171,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to group and ungroup rows and columns for an outline.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup-data" class="ms-Button">
             <span class="ms-Button-label">Add sample data</span>
@@ -186,7 +186,7 @@ template:
         </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="group-rows" class="ms-Button">
             <span class="ms-Button-label">Group rows</span>

--- a/samples/excel/42-range/precedents.yaml
+++ b/samples/excel/42-range/precedents.yaml
@@ -202,11 +202,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/precedents.yaml
+++ b/samples/excel/42-range/precedents.yaml
@@ -159,17 +159,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to find and highlight the precedents of the currently selected cell. </p>
           <p>Precedents are cells referenced by the formula in a cell. A formula can also reference a cell that contains a formula, which results in a series of precedents. A "direct precedent" is a cell directly referenced by the selected formula. This sample shows how to return both the direct precedents and all of the precedents.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3> 
           <button id="setup" class="ms-Button"> 
             <span class="ms-Button-label">Add sample data</span> 
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="select-first-cell" class="ms-Button"> 
             <span class="ms-Button-label">Select a cell with precedents on this worksheet</span> 

--- a/samples/excel/42-range/range-areas.yaml
+++ b/samples/excel/42-range/range-areas.yaml
@@ -171,11 +171,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-areas.yaml
+++ b/samples/excel/42-range/range-areas.yaml
@@ -124,11 +124,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to apply actions simultaneously to multiple, discontiguous ranges. Some of these ranges are found using the Range object's getSpecialCells method.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Set up</h3>
             <button id="reset" class="ms-Button">
                 <span class="ms-Button-label">Populate range / Reset</span>

--- a/samples/excel/42-range/range-auto-fill.yaml
+++ b/samples/excel/42-range/range-auto-fill.yaml
@@ -99,11 +99,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to provide cell data for surrounding cells using auto fill.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup-data" class="ms-Button">
             <span class="ms-Button-label">Add sample data</span>
@@ -114,7 +114,7 @@ template:
         </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="auto-fill-values" class="ms-Button">
             <span class="ms-Button-label">Auto fill values in column F</span>

--- a/samples/excel/42-range/range-auto-fill.yaml
+++ b/samples/excel/42-range/range-auto-fill.yaml
@@ -143,11 +143,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-copyfrom.yaml
+++ b/samples/excel/42-range/range-copyfrom.yaml
@@ -154,16 +154,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to copy data and formatting from one range (<b>A1:E1</b>) to another.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create sample data</span>
             </button>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Try it out</h3>
             <button id="copyAll" class="ms-Button">
                 <span class="ms-Button-label">Copy numbers</span>

--- a/samples/excel/42-range/range-copyfrom.yaml
+++ b/samples/excel/42-range/range-copyfrom.yaml
@@ -212,11 +212,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-dependents.yaml
+++ b/samples/excel/42-range/range-dependents.yaml
@@ -123,17 +123,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to find and highlight the dependents of the currently selected cell. </p>
           <p>Dependent cells contain formulas that refer to other cells.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3> 
           <button id="setup" class="ms-Button"> 
             <span class="ms-Button-label">Add sample data</span> 
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>Cell D3 has dependents across worksheets.</p>
           <button id="select-D3" class="ms-Button">

--- a/samples/excel/42-range/range-dependents.yaml
+++ b/samples/excel/42-range/range-dependents.yaml
@@ -161,11 +161,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-direct-dependents.yaml
+++ b/samples/excel/42-range/range-direct-dependents.yaml
@@ -116,18 +116,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to find and highlight the dependents of the currently selected cell. Dependent cells contain formulas that refer to other cells.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample data</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>Cells in the 'E' column have direct dependents on the same worksheet. Cells in the 'F' column have direct dependents on another worksheet.</p>
           <button id="select-D3" class="ms-Button">

--- a/samples/excel/42-range/range-direct-dependents.yaml
+++ b/samples/excel/42-range/range-direct-dependents.yaml
@@ -156,11 +156,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-find.yaml
+++ b/samples/excel/42-range/range-find.yaml
@@ -158,11 +158,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-find.yaml
+++ b/samples/excel/42-range/range-find.yaml
@@ -113,16 +113,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to find a cell with a matching string value within a range.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create sample data</span>
             </button>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Try it out</h3>
           <p>Enter text to search for in the box below and press <b>Find text</b> or <b> Find text with null check</b> to display the found text's address in the console.</p>
             <textarea id="searchText">Groceries</textarea><p/>

--- a/samples/excel/42-range/range-get-range-edge.yaml
+++ b/samples/excel/42-range/range-get-range-edge.yaml
@@ -219,11 +219,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-get-range-edge.yaml
+++ b/samples/excel/42-range/range-get-range-edge.yaml
@@ -170,17 +170,17 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to select the edges of the used range, based on the currently selected range.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample data</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="select-E9" class="ms-Button">
             <span class="ms-Button-label">Select single cell</span>

--- a/samples/excel/42-range/range-hyperlink.yaml
+++ b/samples/excel/42-range/range-hyperlink.yaml
@@ -314,11 +314,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-hyperlink.yaml
+++ b/samples/excel/42-range/range-hyperlink.yaml
@@ -273,18 +273,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create, update, and clear a hyperlink for a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="create-url-hyperlinks" class="ms-Button">
                 <span class="ms-Button-label">Create URL hyperlinks</span>

--- a/samples/excel/42-range/range-merged-ranges.yaml
+++ b/samples/excel/42-range/range-merged-ranges.yaml
@@ -126,11 +126,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-merged-ranges.yaml
+++ b/samples/excel/42-range/range-merged-ranges.yaml
@@ -92,18 +92,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to create and find merged ranges in a worksheet.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample data</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="create-merged-range" class="ms-Button">
             <span class="ms-Button-label">Create merged range</span>

--- a/samples/excel/42-range/range-relationships.yaml
+++ b/samples/excel/42-range/range-relationships.yaml
@@ -249,11 +249,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-relationships.yaml
+++ b/samples/excel/42-range/range-relationships.yaml
@@ -204,18 +204,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to do various operations on ranges, for example, getting the bounding rect of two ranges.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="intersection" class="ms-Button">
                     <span class="ms-Button-label">Show intersection</span>

--- a/samples/excel/42-range/range-remove-duplicates.yaml
+++ b/samples/excel/42-range/range-remove-duplicates.yaml
@@ -120,11 +120,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-remove-duplicates.yaml
+++ b/samples/excel/42-range/range-remove-duplicates.yaml
@@ -84,18 +84,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to remove rows with duplicate column values from a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="delete-name" class="ms-Button">
                 <span class="ms-Button-label">Delete product name duplicates</span>

--- a/samples/excel/42-range/range-text-orientation.yaml
+++ b/samples/excel/42-range/range-text-orientation.yaml
@@ -114,11 +114,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/range-text-orientation.yaml
+++ b/samples/excel/42-range/range-text-orientation.yaml
@@ -76,18 +76,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set and get the text orientation within a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <label class="ms-font-m">Set the text orientation of the range that encompasses the table headers in the sample data.</label>
             <button id="set-text-orientation" class="ms-Button">

--- a/samples/excel/42-range/selected-range.yaml
+++ b/samples/excel/42-range/selected-range.yaml
@@ -46,11 +46,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the currently selected range.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-selection" class="ms-Button">
                 <span class="ms-Button-label">Get selection</span>

--- a/samples/excel/42-range/selected-range.yaml
+++ b/samples/excel/42-range/selected-range.yaml
@@ -74,11 +74,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/set-get-values.yaml
+++ b/samples/excel/42-range/set-get-values.yaml
@@ -231,11 +231,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/set-get-values.yaml
+++ b/samples/excel/42-range/set-get-values.yaml
@@ -174,18 +174,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set and get values and formulas for a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
 
             <button id="set-value" class="ms-Button">

--- a/samples/excel/42-range/style.yaml
+++ b/samples/excel/42-range/style.yaml
@@ -222,11 +222,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/42-range/style.yaml
+++ b/samples/excel/42-range/style.yaml
@@ -157,18 +157,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, apply, get and delete styles.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p><b>Add new style</b> will throw an error if the style has already been added.</p>
             <button id="add-new-style" class="ms-Button">
@@ -176,31 +176,31 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="apply-new-style" class="ms-Button">
                 <span class="ms-Button-label">Apply new style</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="apply-built-in-style" class="ms-Button">
                 <span class="ms-Button-label">Apply built-in style</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="get-style-font" class="ms-Button">
                 <span class="ms-Button-label">Get style font properties</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <button id="get-style-alignment" class="ms-Button">
                 <span class="ms-Button-label">Get style alignment properties</span>
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Clean up</h3>
             <p><b>Delete new style</b> throws an error if the style doesn't exist (that is, hasn't been added). Deleting the style also causes the other buttons using the style to fail.</p>
             <button id="delete-new-style" class="ms-Button">

--- a/samples/excel/42-range/used-range.yaml
+++ b/samples/excel/42-range/used-range.yaml
@@ -101,18 +101,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample creates a chart from a table, but only if there's data in the table.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="try-create-chart-from-table" class="ms-Button">
                 <span class="ms-Button-label">Try to create chart</span>

--- a/samples/excel/42-range/used-range.yaml
+++ b/samples/excel/42-range/used-range.yaml
@@ -136,11 +136,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/44-shape/shape-create-and-delete.yaml
+++ b/samples/excel/44-shape/shape-create-and-delete.yaml
@@ -129,11 +129,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/44-shape/shape-create-and-delete.yaml
+++ b/samples/excel/44-shape/shape-create-and-delete.yaml
@@ -90,16 +90,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to create different shapes, then delele them.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create new worksheet</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="createHexagon" class="ms-Button">
                 <span class="ms-Button-label">Create hexagon</span>

--- a/samples/excel/44-shape/shape-groups.yaml
+++ b/samples/excel/44-shape/shape-groups.yaml
@@ -105,10 +105,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to group and upgroup shapes in a worksheet.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
@@ -117,7 +117,7 @@ template:
                 <span class="ms-Button-label">Create shapes</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="groupShapes" class="ms-Button">
                 <span class="ms-Button-label">Group shapes together</span>

--- a/samples/excel/44-shape/shape-groups.yaml
+++ b/samples/excel/44-shape/shape-groups.yaml
@@ -144,11 +144,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/44-shape/shape-images.yaml
+++ b/samples/excel/44-shape/shape-images.yaml
@@ -128,11 +128,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/44-shape/shape-images.yaml
+++ b/samples/excel/44-shape/shape-images.yaml
@@ -89,16 +89,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create and use an image-based shape.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Select an image file (JPEG or PNG).</p>
             <input type="file" id="selectedFile"><p>

--- a/samples/excel/44-shape/shape-lines.yaml
+++ b/samples/excel/44-shape/shape-lines.yaml
@@ -218,11 +218,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/44-shape/shape-lines.yaml
+++ b/samples/excel/44-shape/shape-lines.yaml
@@ -161,10 +161,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create and modify line shapes.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
@@ -173,7 +173,7 @@ template:
                 <span class="ms-Button-label">Create shapes</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="addStraightLine" class="ms-Button">
                 <span class="ms-Button-label">Add a straight line</span>

--- a/samples/excel/44-shape/shape-move-and-order.yaml
+++ b/samples/excel/44-shape/shape-move-and-order.yaml
@@ -159,11 +159,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/44-shape/shape-move-and-order.yaml
+++ b/samples/excel/44-shape/shape-move-and-order.yaml
@@ -114,10 +114,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to change the position of shapes, both on the worksheet and their relative positioning when stacked.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
@@ -126,7 +126,7 @@ template:
                 <span class="ms-Button-label">Create shapes</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="moveLeft" class="ms-Button">
                 <span class="ms-Button-label">Move square left</span>

--- a/samples/excel/44-shape/shape-textboxes.yaml
+++ b/samples/excel/44-shape/shape-textboxes.yaml
@@ -92,16 +92,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create and modify textboxes and other shapes with text.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create a worksheet</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="createGeometricShape" class="ms-Button">
                 <span class="ms-Button-label">Create geometric shape with text</span>

--- a/samples/excel/44-shape/shape-textboxes.yaml
+++ b/samples/excel/44-shape/shape-textboxes.yaml
@@ -134,11 +134,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/add-rows-and-columns-to-a-table.yaml
+++ b/samples/excel/46-table/add-rows-and-columns-to-a-table.yaml
@@ -166,11 +166,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/add-rows-and-columns-to-a-table.yaml
+++ b/samples/excel/46-table/add-rows-and-columns-to-a-table.yaml
@@ -127,18 +127,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add columns and rows to a table.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Press the following buttons in order, so rows and columns of appropriate sizes are added.</p>
             <button id="add-row" class="ms-Button">

--- a/samples/excel/46-table/convert-range-to-table.yaml
+++ b/samples/excel/46-table/convert-range-to-table.yaml
@@ -60,18 +60,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to convert a range to a table.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create range</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="convert-range-to-table" class="ms-Button">
                     <span class="ms-Button-label">Convert range to table</span>

--- a/samples/excel/46-table/convert-range-to-table.yaml
+++ b/samples/excel/46-table/convert-range-to-table.yaml
@@ -92,11 +92,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/create-table.yaml
+++ b/samples/excel/46-table/create-table.yaml
@@ -77,11 +77,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/create-table.yaml
+++ b/samples/excel/46-table/create-table.yaml
@@ -52,11 +52,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create a table.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="create-table" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>

--- a/samples/excel/46-table/filter-data.yaml
+++ b/samples/excel/46-table/filter-data.yaml
@@ -88,18 +88,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to filter the data in a table using different filter types.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="filter-table" class="ms-Button">
                 <span class="ms-Button-label">Filter table</span>

--- a/samples/excel/46-table/filter-data.yaml
+++ b/samples/excel/46-table/filter-data.yaml
@@ -123,11 +123,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/formatting.yaml
+++ b/samples/excel/46-table/formatting.yaml
@@ -99,11 +99,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/formatting.yaml
+++ b/samples/excel/46-table/formatting.yaml
@@ -67,18 +67,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to format the different components of a table.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="format-table" class="ms-Button">
                 <span class="ms-Button-label">Format table</span>

--- a/samples/excel/46-table/get-data-from-table.yaml
+++ b/samples/excel/46-table/get-data-from-table.yaml
@@ -114,11 +114,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/get-data-from-table.yaml
+++ b/samples/excel/46-table/get-data-from-table.yaml
@@ -80,18 +80,18 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get data from a table and write it to the sheet.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-data-from-table" class="ms-Button">
                 <span class="ms-Button-label">Get data from a table</span>

--- a/samples/excel/46-table/get-visible-range-of-a-filtered-table.yaml
+++ b/samples/excel/46-table/get-visible-range-of-a-filtered-table.yaml
@@ -137,11 +137,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/get-visible-range-of-a-filtered-table.yaml
+++ b/samples/excel/46-table/get-visible-range-of-a-filtered-table.yaml
@@ -98,11 +98,11 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to filter the data in a table using different filter types.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="create-table" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
@@ -112,7 +112,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-range" class="ms-Button">
                 <span class="ms-Button-label">Get range</span>

--- a/samples/excel/46-table/import-json-data.yaml
+++ b/samples/excel/46-table/import-json-data.yaml
@@ -114,11 +114,11 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to import json data into a new table.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="import-json-data" class="ms-Button">
                 <span class="ms-Button-label">Import JSON data</span>

--- a/samples/excel/46-table/import-json-data.yaml
+++ b/samples/excel/46-table/import-json-data.yaml
@@ -140,11 +140,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/resize-table.yaml
+++ b/samples/excel/46-table/resize-table.yaml
@@ -95,11 +95,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/46-table/resize-table.yaml
+++ b/samples/excel/46-table/resize-table.yaml
@@ -64,18 +64,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to resize a table.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Create table</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="resize-table" class="ms-Button">
             <span class="ms-Button-label">Resize table</span>

--- a/samples/excel/46-table/sort-data.yaml
+++ b/samples/excel/46-table/sort-data.yaml
@@ -74,18 +74,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to sort the data in a table.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="sort-table" class="ms-Button">
                 <span class="ms-Button-label">Sort table</span>

--- a/samples/excel/46-table/sort-data.yaml
+++ b/samples/excel/46-table/sort-data.yaml
@@ -106,11 +106,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/create-get-change-delete-settings.yaml
+++ b/samples/excel/50-workbook/create-get-change-delete-settings.yaml
@@ -74,11 +74,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create, get, change, and delete settings in the workbook.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Press the button to create and display a setting.</p>
             <button id="create-setting" class="ms-Button">

--- a/samples/excel/50-workbook/create-get-change-delete-settings.yaml
+++ b/samples/excel/50-workbook/create-get-change-delete-settings.yaml
@@ -108,11 +108,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/create-workbook.yaml
+++ b/samples/excel/50-workbook/create-workbook.yaml
@@ -48,11 +48,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create a new, empty workbook and how to create a new workbook by copying an existing one.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p><b>Create empty workbook</b></p>
             <button id="create-new-blank-workbook" class="ms-Button">

--- a/samples/excel/50-workbook/create-workbook.yaml
+++ b/samples/excel/50-workbook/create-workbook.yaml
@@ -79,11 +79,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/culture-info-date-time.yaml
+++ b/samples/excel/50-workbook/culture-info-date-time.yaml
@@ -105,13 +105,13 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to use the read-only cultural settings APIs to retrieve system date and time settings.</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Setup</h3> <button id="setup" class="ms-Button"> <span class="ms-Button-label">Setup</span> </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="display-date-time-setting" class="ms-Button"> <span class="ms-Button-label">Display date/time settings</span> </button>
           <p></p>

--- a/samples/excel/50-workbook/culture-info-date-time.yaml
+++ b/samples/excel/50-workbook/culture-info-date-time.yaml
@@ -132,11 +132,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/culture-info.yaml
+++ b/samples/excel/50-workbook/culture-info.yaml
@@ -108,18 +108,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to apply the cultural settings APIs to help normalize data.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="display-culture-info" class="ms-Button">
               <span class="ms-Button-label">Display culture settings</span>

--- a/samples/excel/50-workbook/culture-info.yaml
+++ b/samples/excel/50-workbook/culture-info.yaml
@@ -146,11 +146,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/data-protection.yaml
+++ b/samples/excel/50-workbook/data-protection.yaml
@@ -252,11 +252,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/data-protection.yaml
+++ b/samples/excel/50-workbook/data-protection.yaml
@@ -175,18 +175,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to protect a worksheet's data and the workbook's structure.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                         <span class="ms-Button-label">Add sample data</span>
                     </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Protect without password</h4>
             <p>

--- a/samples/excel/50-workbook/workbook-built-in-functions.yaml
+++ b/samples/excel/50-workbook/workbook-built-in-functions.yaml
@@ -114,11 +114,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/workbook-built-in-functions.yaml
+++ b/samples/excel/50-workbook/workbook-built-in-functions.yaml
@@ -80,11 +80,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to use and nest the built-in Excel functions <code>VLOOKUP</code> and <code>SUM</code>. The sample uses <code>VLOOKUP</code> to return data, and then it uses <code>SUM</code> to combine data returned by <code>VLOOKUP</code>.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Setup</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Create table</span>

--- a/samples/excel/50-workbook/workbook-calculation.yaml
+++ b/samples/excel/50-workbook/workbook-calculation.yaml
@@ -134,18 +134,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to use the calculation APIs.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Add sample data</span>
           </button>
         </section>
               
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
 
             <p><b>Calculation events</b></p>

--- a/samples/excel/50-workbook/workbook-calculation.yaml
+++ b/samples/excel/50-workbook/workbook-calculation.yaml
@@ -187,11 +187,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/workbook-get-active-cell.yaml
+++ b/samples/excel/50-workbook/workbook-get-active-cell.yaml
@@ -60,11 +60,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/workbook-get-active-cell.yaml
+++ b/samples/excel/50-workbook/workbook-get-active-cell.yaml
@@ -35,11 +35,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the active cell of the entire workbook.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-active-cell" class="ms-Button">
                 <span class="ms-Button-label">Get active cell</span>

--- a/samples/excel/50-workbook/workbook-insert-external-worksheets.yaml
+++ b/samples/excel/50-workbook/workbook-insert-external-worksheets.yaml
@@ -88,11 +88,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/workbook-insert-external-worksheets.yaml
+++ b/samples/excel/50-workbook/workbook-insert-external-worksheets.yaml
@@ -57,11 +57,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to copy the worksheets from an existing workbook into the current workbook.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Select an Excel workbook to copy its worksheets into the current workbook.</p>
             <form>

--- a/samples/excel/50-workbook/workbook-save-and-close.yaml
+++ b/samples/excel/50-workbook/workbook-save-and-close.yaml
@@ -82,11 +82,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/50-workbook/workbook-save-and-close.yaml
+++ b/samples/excel/50-workbook/workbook-save-and-close.yaml
@@ -48,11 +48,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to save a workbook, both with and without a prompt to the user, and how to close the workbook.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="saveWithPrompt" class="ms-Button">
                 <span class="ms-Button-label">Save (with a first-save prompt)</span>

--- a/samples/excel/54-worksheet/active-worksheet.yaml
+++ b/samples/excel/54-worksheet/active-worksheet.yaml
@@ -119,11 +119,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/active-worksheet.yaml
+++ b/samples/excel/54-worksheet/active-worksheet.yaml
@@ -84,18 +84,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the active worksheet.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Ensure two worksheets</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-active-worksheet" class="ms-Button">
                 <span class="ms-Button-label">Get active worksheet</span>

--- a/samples/excel/54-worksheet/add-delete-rename-move-worksheet.yaml
+++ b/samples/excel/54-worksheet/add-delete-rename-move-worksheet.yaml
@@ -104,11 +104,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, delete, rename and change the position of a worksheet.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-worksheet" class="ms-Button">
                 <span class="ms-Button-label">Add worksheet</span>

--- a/samples/excel/54-worksheet/add-delete-rename-move-worksheet.yaml
+++ b/samples/excel/54-worksheet/add-delete-rename-move-worksheet.yaml
@@ -138,11 +138,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/gridlines.yaml
+++ b/samples/excel/54-worksheet/gridlines.yaml
@@ -73,11 +73,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/gridlines.yaml
+++ b/samples/excel/54-worksheet/gridlines.yaml
@@ -42,11 +42,11 @@ script:
     language: typescript
 template:
     content: |+
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to hide and show gridlines within a worksheet.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <label class="ms-font-m">Hide gridlines within the active worksheet.</label>
             <button id="hide-gridlines" class="ms-Button">

--- a/samples/excel/54-worksheet/list-worksheets.yaml
+++ b/samples/excel/54-worksheet/list-worksheets.yaml
@@ -41,11 +41,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to list the names of the worksheets in the workbook.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="list-worksheets" class="ms-Button">
                 <span class="ms-Button-label">List worksheets</span>

--- a/samples/excel/54-worksheet/list-worksheets.yaml
+++ b/samples/excel/54-worksheet/list-worksheets.yaml
@@ -66,11 +66,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/reference-worksheets-by-relative-position.yaml
+++ b/samples/excel/54-worksheet/reference-worksheets-by-relative-position.yaml
@@ -120,18 +120,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get a reference to a sheet using its relative worksheet position.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create sample worksheets</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Select any of the three worksheets for 2015, 1016, or 2017 and press the button to compare the <b>tax due</b> on the current sheet with the previous sheet.</p>
             <button id="compare-current-and-previous-year" class="ms-Button">

--- a/samples/excel/54-worksheet/reference-worksheets-by-relative-position.yaml
+++ b/samples/excel/54-worksheet/reference-worksheets-by-relative-position.yaml
@@ -157,11 +157,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/tab-color.yaml
+++ b/samples/excel/54-worksheet/tab-color.yaml
@@ -102,11 +102,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/tab-color.yaml
+++ b/samples/excel/54-worksheet/tab-color.yaml
@@ -65,11 +65,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set and get the tab color of a worksheet.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <label class="ms-font-m">Set tab color for the active worksheet.</label>
             <button id="set-tab-color-to-hex-color" class="ms-Button">

--- a/samples/excel/54-worksheet/worksheet-auto-filter.yaml
+++ b/samples/excel/54-worksheet/worksheet-auto-filter.yaml
@@ -153,18 +153,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to work with an AutoFilter on a worksheet.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Add two filters. One shows only the top half of sales and the other shows only fruits that end with the letter 'e'.</p>
             <button id="add-percent-auto-filter" class="ms-Button">

--- a/samples/excel/54-worksheet/worksheet-auto-filter.yaml
+++ b/samples/excel/54-worksheet/worksheet-auto-filter.yaml
@@ -207,11 +207,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/worksheet-copy.yaml
+++ b/samples/excel/54-worksheet/worksheet-copy.yaml
@@ -98,11 +98,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/worksheet-copy.yaml
+++ b/samples/excel/54-worksheet/worksheet-copy.yaml
@@ -66,18 +66,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to copy a worksheet.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                         <span class="ms-Button-label">Add sample data</span>
                     </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="copy-worksheet" class="ms-Button">
                 <span class="ms-Button-label">Copy worksheet</span>

--- a/samples/excel/54-worksheet/worksheet-find-all.yaml
+++ b/samples/excel/54-worksheet/worksheet-find-all.yaml
@@ -104,16 +104,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to find cells with matching string values across an entire worksheet.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create sample data</span>
             </button>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Try it out</h3>
             <button id="findCompleted" class="ms-Button">
                 <span class="ms-Button-label">Highlight complete projects</span>

--- a/samples/excel/54-worksheet/worksheet-find-all.yaml
+++ b/samples/excel/54-worksheet/worksheet-find-all.yaml
@@ -140,11 +140,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/worksheet-freeze-panes.yaml
+++ b/samples/excel/54-worksheet/worksheet-freeze-panes.yaml
@@ -128,18 +128,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to freeze columns, freeze rows, freeze a range, and manage frozen panes in a worksheet.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="freeze-columns" class="ms-Button">
                 <span class="ms-Button-label">Freeze columns</span>

--- a/samples/excel/54-worksheet/worksheet-freeze-panes.yaml
+++ b/samples/excel/54-worksheet/worksheet-freeze-panes.yaml
@@ -172,11 +172,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/worksheet-page-layout.yaml
+++ b/samples/excel/54-worksheet/worksheet-page-layout.yaml
@@ -203,11 +203,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/worksheet-page-layout.yaml
+++ b/samples/excel/54-worksheet/worksheet-page-layout.yaml
@@ -145,16 +145,16 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to change page layout and other settings for printing a worksheet.</p>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Create sample data</span>
             </button>
         </section>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Try it out</h3>
             <p>In Excel, choose <b>View > Page Layout</b>, then observe the page layout changes as you press the following
                 buttons.</p>

--- a/samples/excel/54-worksheet/worksheet-range-cell.yaml
+++ b/samples/excel/54-worksheet/worksheet-range-cell.yaml
@@ -143,11 +143,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/worksheet-range-cell.yaml
+++ b/samples/excel/54-worksheet/worksheet-range-cell.yaml
@@ -102,18 +102,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get a range or a cell in a worksheet.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-used-range" class="ms-Button">
                 <span class="ms-Button-label">Get used range</span>

--- a/samples/excel/54-worksheet/worksheet-visibility.yaml
+++ b/samples/excel/54-worksheet/worksheet-visibility.yaml
@@ -118,11 +118,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/54-worksheet/worksheet-visibility.yaml
+++ b/samples/excel/54-worksheet/worksheet-visibility.yaml
@@ -83,18 +83,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to change the visbility of a worksheet.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Ensure two worksheets</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="hide-worksheet" class="ms-Button">
                 <span class="ms-Button-label">Hide worksheet</span>

--- a/samples/excel/90-scenarios/currency-converter.yaml
+++ b/samples/excel/90-scenarios/currency-converter.yaml
@@ -182,10 +182,10 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
     core-js@2.4.1/client/core.min.js
     @types/core-js
     jquery@3.1.1

--- a/samples/excel/90-scenarios/currency-converter.yaml
+++ b/samples/excel/90-scenarios/currency-converter.yaml
@@ -142,25 +142,25 @@ script:
     language: typescript
 template:
     content: |
-        <header class="ms-welcome__header ms-bgColor-neutralLighter" style='text-align: center'>
+        <header class="ms-Fabric ms-welcome__header ms-bgColor-neutralLighter" style='text-align: center'>
           <h1 class="ms-font-su">Simple Currency Converter</h1>
         </header>
 
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>Simple currency converter shows how to read data from a transaction table, and uses currency converter API to
             calculate the amount in base currency. </p>
           <p>The code also performs table validation and identify if the table has predefined headers. You can try to to rearrange the the
             column, and see by yourself! </p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>The currency conversion is provided by <a href="https://exchangeratesapi.io">exchangeratesapi.io</a> which uses
             exchange rate data published by the European Central Bank. Click "Convert"</p>

--- a/samples/excel/90-scenarios/multiple-property-set.yaml
+++ b/samples/excel/90-scenarios/multiple-property-set.yaml
@@ -130,11 +130,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/90-scenarios/multiple-property-set.yaml
+++ b/samples/excel/90-scenarios/multiple-property-set.yaml
@@ -95,18 +95,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to format a range.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-multiple-properties-with-object" class="ms-Button">
                 <span class="ms-Button-label">Set Multiple Properties with Object</span>

--- a/samples/excel/90-scenarios/performance-optimization.yaml
+++ b/samples/excel/90-scenarios/performance-optimization.yaml
@@ -185,11 +185,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/90-scenarios/performance-optimization.yaml
+++ b/samples/excel/90-scenarios/performance-optimization.yaml
@@ -134,19 +134,19 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows some performance optimizations. Toggle the various performance options, then refresh or
                 recalculate to see the effects.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Setup</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Setup</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Performance settings</h3>
             <button id="toggle-screen-painting" class="ms-Button">
                     <span class="ms-Button-label">Toggle screen painting</span>
@@ -160,7 +160,7 @@ template:
                     <span class="ms-Button-label">Toggle calculation mode</span>
             </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="refresh-data" class="ms-Button">
                     <span class="ms-Button-label">Refresh data</span>

--- a/samples/excel/90-scenarios/report-generation.yaml
+++ b/samples/excel/90-scenarios/report-generation.yaml
@@ -145,11 +145,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/90-scenarios/report-generation.yaml
+++ b/samples/excel/90-scenarios/report-generation.yaml
@@ -120,11 +120,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to load sample data into the worksheet, and then create a chart.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="create-report" class="ms-Button">
                 <span class="ms-Button-label">Create report</span>

--- a/samples/excel/90-scenarios/working-with-dates.yaml
+++ b/samples/excel/90-scenarios/working-with-dates.yaml
@@ -130,11 +130,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/90-scenarios/working-with-dates.yaml
+++ b/samples/excel/90-scenarios/working-with-dates.yaml
@@ -95,18 +95,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set and get date values in a range and manipulating them using the Moment JavaScript library with the Moment-MSDate plug-in.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample data</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-date-value-using-timestamp" class="ms-Button">
                 <span class="ms-Button-label">Set date value using timestamp</span>

--- a/samples/excel/99-just-for-fun/color-wheel.yaml
+++ b/samples/excel/99-just-for-fun/color-wheel.yaml
@@ -112,7 +112,9 @@ script:
     language: typescript
 template:
     content: |+
-        <h2 class="ms-font-l">Spin the rainbow wheel</h2>
+        <header class="ms-Fabric">
+            <h2 class="ms-font-l">Spin the rainbow wheel</h2>
+        </header>
         <br/>
         <button id="wheel" class="ms-Button ms-Button--primary">
                 <span class="ms-Button-label">Start the Wheel</span>

--- a/samples/excel/99-just-for-fun/color-wheel.yaml
+++ b/samples/excel/99-just-for-fun/color-wheel.yaml
@@ -143,11 +143,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/99-just-for-fun/gradient.yaml
+++ b/samples/excel/99-just-for-fun/gradient.yaml
@@ -130,43 +130,47 @@ script:
     language: typescript
 template:
     content: |-
-        <h2 class="ms-font-l">Color configuration</h2>
+        <header class="ms-Fabric">
+            <h2 class="ms-font-l">Color configuration</h2>
+        </header>
 
-        <div id="color-table" class="ms-font-s">
-            <div>Top left</div>
-            <table class="ms-font-m">
-                <tr>
-                    <td><input id="top-left" type="text" value="red" /></td>
-                    <td><input id="top-right" type="text" value="lime" /></td>
-                </tr>
-                <tr>
-                    <td><input id="bottom-left" type="text" value="blue" /></td>
-                    <td><input id="bottom-right" type="text" value="yellow" /></td>
-                </tr>
-            </table>
-            <div>
-                Bottom right
+        <section class="ms-Fabric">
+            <div id="color-table" class="ms-font-s">
+                <div>Top left</div>
+                <table class="ms-font-m">
+                    <tr>
+                        <td><input id="top-left" type="text" value="red" /></td>
+                        <td><input id="top-right" type="text" value="lime" /></td>
+                    </tr>
+                    <tr>
+                        <td><input id="bottom-left" type="text" value="blue" /></td>
+                        <td><input id="bottom-right" type="text" value="yellow" /></td>
+                    </tr>
+                </table>
+                <div>
+                    Bottom right
+                </div>
             </div>
-        </div>
 
-        <button id="random" class="ms-Button">
-            <span class="ms-Button-label">Randomize colors</span>
-        </button>
+            <button id="random" class="ms-Button">
+                <span class="ms-Button-label">Randomize colors</span>
+            </button>
 
-        <h2 class="ms-font-l">Size
-            <span class="ms-font-m">(width x height)</span>
-        </h2>
-        <input id="size" type="range" value="25" min="2" max="100"></input>
+            <h2 class="ms-font-l">Size
+                <span class="ms-font-m">(width x height)</span>
+            </h2>
+            <input id="size" type="range" value="25" min="2" max="100"></input>
 
-        <button id="draw-gradient" class="ms-Button ms-Button--primary">
-            <span class="ms-Button-label ms-font-l">Draw gradient</span>
-        </button>
+            <button id="draw-gradient" class="ms-Button ms-Button--primary">
+                <span class="ms-Button-label ms-font-l">Draw gradient</span>
+            </button>
 
-        <div id="credits">
-            <div class="ms-font-s">
-                Uses the <a href="https://github.com/bgrins/spectrum" target="_blank">Spectrum color picker</a>, and the <a href="https://github.com/bgrins/TinyColor" target="_blank">TinyColor</a> libraries.
+            <div id="credits">
+                <div class="ms-font-s">
+                    Uses the <a href="https://github.com/bgrins/spectrum" target="_blank">Spectrum color picker</a>, and the <a href="https://github.com/bgrins/TinyColor" target="_blank">TinyColor</a> libraries.
+                </div>
             </div>
-        </div>
+        </section>
     language: html
 style:
     content: |-

--- a/samples/excel/99-just-for-fun/gradient.yaml
+++ b/samples/excel/99-just-for-fun/gradient.yaml
@@ -207,11 +207,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/99-just-for-fun/path-finder-game.yaml
+++ b/samples/excel/99-just-for-fun/path-finder-game.yaml
@@ -222,11 +222,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/99-just-for-fun/path-finder-game.yaml
+++ b/samples/excel/99-just-for-fun/path-finder-game.yaml
@@ -175,12 +175,12 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>Check whether there is a path from left to right, moving forward one cell at a time (and only straight or diagonally). </p>
         </section>
 
         <h3 class="ms-font-l">Set up</h3>
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <div>Circle density (%)</div>
             <input id="density" type="range" min="0" max="100" value="50"></input>
             <button id="setup" class="ms-Button ms-Button--primary">
@@ -193,7 +193,7 @@ template:
         <br />
 
         <h3 class="ms-font-l">Find the path:</h3>
-        <section class="find-path ms-font-m">
+        <section class="ms-Fabric find-path ms-font-m">
                 <button id="all-at-once" class="ms-Button ms-Button--primary">
                 <span class="ms-Button-label">Prune all at once</span>
             </button>

--- a/samples/excel/99-just-for-fun/patterns.yaml
+++ b/samples/excel/99-just-for-fun/patterns.yaml
@@ -155,14 +155,14 @@ script:
     language: typescript
 template:
     content: |-
-        <h2 class="ms-font-l">Draw colorful patterns</h2>
+        <h2 class="ms-Fabric ms-font-l">Draw colorful patterns</h2>
 
-        <section class="ms-font-m" style="margin-top: 30px">
+        <section class="ms-Fabric ms-font-m" style="margin-top: 30px">
             <div>Choose size:</div>
             <input id="size" type="range" min="2" max="50" value="30"></input>
         </section>
 
-        <section class="ms-font-m" style="margin-top: 30px">
+        <section class="ms-Fabric ms-font-m" style="margin-top: 30px">
             <button id="squares" class="ms-Button ">
                 <span class="ms-Button-label">Concentric Squares</span>
             </button>

--- a/samples/excel/99-just-for-fun/patterns.yaml
+++ b/samples/excel/99-just-for-fun/patterns.yaml
@@ -189,11 +189,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/99-just-for-fun/tetrominos.yaml
+++ b/samples/excel/99-just-for-fun/tetrominos.yaml
@@ -646,28 +646,28 @@ script:
 template:
     content: |-
         <div id="container" class="container">
-            <section class="ms-font-m">
+            <section class="ms-Fabric ms-font-m">
                 <p>This sample lets you repeatedly stack tetrominos, which are represented by Shapes. Select a background image (or leave blank for the default) and <b>Start!</b>. The controls will then be displayed.</p>
             </section>
 
-            <section class="samples ms-font-m" id="setup">
+            <section class="ms-Fabric samples ms-font-m" id="setup">
                 <p>Select Background Image</p>
                 <input type="file" id="selectedFile"><p>
                 <button id="run" class="ms-Button">
                     <span class="ms-Button-label">Start!</span>
                 </button>
             </section>
-            <section class="samples ms-font-m">
+            <section class="ms-Fabric samples ms-font-m">
                 <div id="sessionPane">
                 </div>
             </section>
             <p/>
-            <section class="samples ms-font-m" id="focus" hidden="true">
+            <section class="ms-Fabric samples ms-font-m" id="focus" hidden="true">
                 <p>Use the <b>Keyboard Focus</b> button if the keyboard controls aren't working (to regain focus on the task pane).</p>
                 <button id="focusButton" class="ms-Button" >
                     <span class="ms-Button-label">Keyboard Focus</span>
                 </button>
-            <section class="samples ms-font-m" id="setup">
+            <section class="ms-Fabric samples ms-font-m" id="setup">
         </div>
     language: html
 style:

--- a/samples/excel/99-just-for-fun/tetrominos.yaml
+++ b/samples/excel/99-just-for-fun/tetrominos.yaml
@@ -785,11 +785,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/excel/default.yaml
+++ b/samples/excel/default.yaml
@@ -50,11 +50,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/onenote/default.yaml
+++ b/samples/onenote/default.yaml
@@ -48,11 +48,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/10-roaming-settings/roaming-settings.yaml
+++ b/samples/outlook/10-roaming-settings/roaming-settings.yaml
@@ -76,11 +76,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/10-roaming-settings/roaming-settings.yaml
+++ b/samples/outlook/10-roaming-settings/roaming-settings.yaml
@@ -37,11 +37,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to set, save, and get add-in properties that can be accessed the next time the add-in is opened.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <div class="ms-TextField">
             <label class="ms-Label">Setting name:</label>

--- a/samples/outlook/15-item-custom-properties/load-set-get-save.yaml
+++ b/samples/outlook/15-item-custom-properties/load-set-get-save.yaml
@@ -128,11 +128,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/15-item-custom-properties/load-set-get-save.yaml
+++ b/samples/outlook/15-item-custom-properties/load-set-get-save.yaml
@@ -70,11 +70,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set, save, and get the custom per-item properties of an add-in.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>First load the <a href="https://learn.microsoft.com/javascript/api/outlook/office.customproperties"
                     target="_blank">CustomProperties</a> object of the mail item.</p>

--- a/samples/outlook/20-item-body/add-inline-base64-image.yaml
+++ b/samples/outlook/20-item-body/add-inline-base64-image.yaml
@@ -69,11 +69,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/20-item-body/add-inline-base64-image.yaml
+++ b/samples/outlook/20-item-body/add-inline-base64-image.yaml
@@ -43,12 +43,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p class="ms-font-m">This sample adds an inline Base64 image to the body of the message or appointment being composed.</p>
           <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="add-image" class="ms-Button">
             <span class="ms-Button-label">Add an inline Base64 image</span>

--- a/samples/outlook/20-item-body/append-text-on-send.yaml
+++ b/samples/outlook/20-item-body/append-text-on-send.yaml
@@ -34,12 +34,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample appends text to the end of the message or appointment's body once it's sent.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p><b>Important</b>: To use <code>appendOnSendAsync</code>, you must set <code>AppendOnSend</code> as an extended permission in the <code>ExtendedPermissions</code> manifest element. To learn more about append-on-send and its configuration, see <a href="https://learn.microsoft.com/office/dev/add-ins/outlook/append-on-send" target="_blank">Implement append-on-send in your Outlook add-in</a>.</p>
             <div class="ms-TextField">

--- a/samples/outlook/20-item-body/append-text-on-send.yaml
+++ b/samples/outlook/20-item-body/append-text-on-send.yaml
@@ -66,11 +66,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/20-item-body/get-body-format.yaml
+++ b/samples/outlook/20-item-body/get-body-format.yaml
@@ -49,11 +49,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/20-item-body/get-body-format.yaml
+++ b/samples/outlook/20-item-body/get-body-format.yaml
@@ -23,12 +23,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample gets the message or appointment's body format (plain text or HTML).</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-body-format" class="ms-Button">
               <span class="ms-Button-label">Get body format</span>

--- a/samples/outlook/20-item-body/get-selected-data.yaml
+++ b/samples/outlook/20-item-body/get-selected-data.yaml
@@ -23,12 +23,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the selected text in the item body or subject/title.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Select text in the item body or subject then push the <b>Get selected text</b> button.</p>
             <button id="get-selected-data" class="ms-Button">

--- a/samples/outlook/20-item-body/get-selected-data.yaml
+++ b/samples/outlook/20-item-body/get-selected-data.yaml
@@ -50,11 +50,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/20-item-body/prepend-text-on-send.yaml
+++ b/samples/outlook/20-item-body/prepend-text-on-send.yaml
@@ -66,11 +66,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/20-item-body/prepend-text-on-send.yaml
+++ b/samples/outlook/20-item-body/prepend-text-on-send.yaml
@@ -34,12 +34,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample prepends text to the beginning of the message or appointment's body once it's sent.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p><b>Important</b>: To use <code>prependOnSendAsync</code>, you must set <code>AppendOnSend</code> as an extended permission in the <code>ExtendedPermissions</code> manifest element. <code>appendOnSendAsync</code> and <code>prependOnSendAsync</code> both use the <code>AppendOnSend</code> extended permission. To learn more about prepend-on-send, see <a href="https://learn.microsoft.com/office/dev/add-ins/outlook/append-on-send" target="_blank">Prepend or append content to a message or appointment body on send</a>.</p>
             <div class="ms-TextField">

--- a/samples/outlook/20-item-body/prepend-text-to-item-body.yaml
+++ b/samples/outlook/20-item-body/prepend-text-to-item-body.yaml
@@ -37,12 +37,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample adds text to the beginning of the message or appointment's body.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
                 <label class="ms-Label">Enter text to prepend to the body: </label>

--- a/samples/outlook/20-item-body/prepend-text-to-item-body.yaml
+++ b/samples/outlook/20-item-body/prepend-text-to-item-body.yaml
@@ -68,11 +68,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/20-item-body/replace-selected-text.yaml
+++ b/samples/outlook/20-item-body/replace-selected-text.yaml
@@ -37,12 +37,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample replaces selected text in a message or appointment's body with specified text.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <ol>
                 <li>Select text in the item's body.</li>

--- a/samples/outlook/20-item-body/replace-selected-text.yaml
+++ b/samples/outlook/20-item-body/replace-selected-text.yaml
@@ -72,11 +72,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/25-item-save-and-close/close-async.yaml
+++ b/samples/outlook/25-item-save-and-close/close-async.yaml
@@ -25,12 +25,12 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to close the current message being composed and discard any unsaved changes.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="close-async" class="ms-Button">
                 <span class="ms-Button-label">Close message and discard changes</span>

--- a/samples/outlook/25-item-save-and-close/close-async.yaml
+++ b/samples/outlook/25-item-save-and-close/close-async.yaml
@@ -51,11 +51,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/25-item-save-and-close/close.yaml
+++ b/samples/outlook/25-item-save-and-close/close.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to close the item in compose mode.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Close</div>

--- a/samples/outlook/25-item-save-and-close/close.yaml
+++ b/samples/outlook/25-item-save-and-close/close.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/25-item-save-and-close/save.yaml
+++ b/samples/outlook/25-item-save-and-close/save.yaml
@@ -47,11 +47,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/25-item-save-and-close/save.yaml
+++ b/samples/outlook/25-item-save-and-close/save.yaml
@@ -22,11 +22,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to save the item in compose mode.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Save</div>

--- a/samples/outlook/30-recipients-and-attendees/get-all-attendees.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-all-attendees.yaml
@@ -118,11 +118,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-all-attendees.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-all-attendees.yaml
@@ -92,12 +92,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get all appointment attendees and organize them by their response.</p>
             <p><b>Required mode</b>: Appointment Organizer, Appointment Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-attendees" class="ms-Button">
               <span class="ms-Button-label">Get attendees</span>

--- a/samples/outlook/30-recipients-and-attendees/get-cc-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-cc-message-read.yaml
@@ -45,11 +45,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-cc-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-cc-message-read.yaml
@@ -19,12 +19,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the <b>Cc</b> line recipients of the email.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-cc" class="ms-Button">
             <span class="ms-Button-label">Who is copied?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-from-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-from-message-compose.yaml
@@ -22,12 +22,12 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get who an email is <b>from</b>.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-from" class="ms-Button">
             <span class="ms-Button-label">Who is this from?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-from-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-from-message-compose.yaml
@@ -48,11 +48,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-from-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-from-message-read.yaml
@@ -16,13 +16,13 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get who an email is <b>from</b>. In a delegate access scenario, the
                 <b>from</b> property represents the delegator. <b>Tip</b>: Use <b>sender</b> to get the delegate.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-from" class="ms-Button">
             <span class="ms-Button-label">Who is this from?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-from-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-from-message-read.yaml
@@ -43,11 +43,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-optional-attendees-appointment-attendee.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-optional-attendees-appointment-attendee.yaml
@@ -25,12 +25,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the <b>optional attendees</b>.</p>
             <p><b>Required mode</b>: Appointment Attendee</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-optional-attendees" class="ms-Button">
             <span class="ms-Button-label">Who are the optional attendees?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-optional-attendees-appointment-attendee.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-optional-attendees-appointment-attendee.yaml
@@ -51,11 +51,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-attendee.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-attendee.yaml
@@ -42,11 +42,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-attendee.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-attendee.yaml
@@ -16,12 +16,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the appointment <b>organizer</b>.</p>
             <p><b>Required mode</b>: Appointment Attendee</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-organizer" class="ms-Button">
             <span class="ms-Button-label">Who is the organizer?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-organizer.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-organizer.yaml
@@ -22,12 +22,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the appointment <b>organizer</b>.</p>
             <p><b>Required mode</b>: Appointment Organizer</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-organizer" class="ms-Button">
             <span class="ms-Button-label">Who is the organizer?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-organizer.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-organizer-appointment-organizer.yaml
@@ -48,11 +48,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-required-attendees-appointment-attendee.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-required-attendees-appointment-attendee.yaml
@@ -25,12 +25,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the <b>required attendees</b>.</p>
             <p><b>Required mode</b>: Appointment Attendee</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-required-attendees" class="ms-Button">
             <span class="ms-Button-label">Who are the required attendees?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-required-attendees-appointment-attendee.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-required-attendees-appointment-attendee.yaml
@@ -51,11 +51,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-sender-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-sender-message-read.yaml
@@ -42,11 +42,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-sender-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-sender-message-read.yaml
@@ -16,12 +16,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the email <b>sender</b>. In a delegate access scenario, the sender is the delegate. <b>Tip</b>: Use the <b>from</b> property to get the delegator.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-sender" class="ms-Button">
             <span class="ms-Button-label">Who is the sender?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-set-bcc-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-bcc-message-compose.yaml
@@ -40,12 +40,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get and set the <b>Bcc</b> line recipients of the email.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
                 <label class="ms-Label">Email address</label>

--- a/samples/outlook/30-recipients-and-attendees/get-set-bcc-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-bcc-message-compose.yaml
@@ -73,11 +73,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-set-cc-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-cc-message-compose.yaml
@@ -73,11 +73,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-set-cc-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-cc-message-compose.yaml
@@ -40,12 +40,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get and set the <b>Cc</b> line recipients of the email.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
                 <label class="ms-Label">Email address</label>

--- a/samples/outlook/30-recipients-and-attendees/get-set-optional-attendees-appointment-organizer.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-optional-attendees-appointment-organizer.yaml
@@ -46,12 +46,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get and set the <b>optional attendees</b>.</p>
             <p><b>Required mode</b>: Appointment Organizer</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
                 <label class="ms-Label">Email address</label>

--- a/samples/outlook/30-recipients-and-attendees/get-set-optional-attendees-appointment-organizer.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-optional-attendees-appointment-organizer.yaml
@@ -79,11 +79,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-set-required-attendees-appointment-organizer.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-required-attendees-appointment-organizer.yaml
@@ -46,12 +46,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get and set the <b>required attendees</b>.</p>
             <p><b>Required mode</b>: Appointment Organizer</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
               <label class="ms-Label">Email address</label>

--- a/samples/outlook/30-recipients-and-attendees/get-set-required-attendees-appointment-organizer.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-required-attendees-appointment-organizer.yaml
@@ -79,11 +79,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-set-to-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-to-message-compose.yaml
@@ -73,11 +73,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/30-recipients-and-attendees/get-set-to-message-compose.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-set-to-message-compose.yaml
@@ -40,12 +40,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get and set the <b>To</b> line recipients of the email.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
                 <label class="ms-Label">Email address</label>

--- a/samples/outlook/30-recipients-and-attendees/get-to-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-to-message-read.yaml
@@ -54,12 +54,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the <b>To</b> line recipients of the email.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-to" class="ms-Button">
             <span class="ms-Button-label">To whom is this sent?</span>

--- a/samples/outlook/30-recipients-and-attendees/get-to-message-read.yaml
+++ b/samples/outlook/30-recipients-and-attendees/get-to-message-read.yaml
@@ -80,11 +80,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/35-notifications/add-getall-remove.yaml
+++ b/samples/outlook/35-notifications/add-getall-remove.yaml
@@ -125,11 +125,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to add different kinds of notification messages, get all, replace, and remove an individual notification message.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h2>Try it out</h2>
           <div class="ms-TextField">
             <label class="ms-Label">Notification ID to add, replace, or remove that notification:</label>

--- a/samples/outlook/35-notifications/add-getall-remove.yaml
+++ b/samples/outlook/35-notifications/add-getall-remove.yaml
@@ -192,11 +192,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/40-attachments/attachments-compose.yaml
+++ b/samples/outlook/40-attachments/attachments-compose.yaml
@@ -109,12 +109,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, get, and remove attachments from a message or an appointment in Compose mode.</p>
             <p><b>Required mode</b>: Item Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <hr>
             <h4>ADD</h4>

--- a/samples/outlook/40-attachments/attachments-compose.yaml
+++ b/samples/outlook/40-attachments/attachments-compose.yaml
@@ -158,11 +158,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/40-attachments/get-attachment-content.yaml
+++ b/samples/outlook/40-attachments/get-attachment-content.yaml
@@ -78,12 +78,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample gets the attachment content from a message or an appointment in read or compose mode.</p>
             <p><b>Required mode</b>: Compose or Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="attachment-content-compose" class="ms-Button">
             <span class="ms-Button-label">Get attachment content (Compose)</span>

--- a/samples/outlook/40-attachments/get-attachment-content.yaml
+++ b/samples/outlook/40-attachments/get-attachment-content.yaml
@@ -107,11 +107,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/40-attachments/get-attachments-read.yaml
+++ b/samples/outlook/40-attachments/get-attachments-read.yaml
@@ -41,11 +41,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/40-attachments/get-attachments-read.yaml
+++ b/samples/outlook/40-attachments/get-attachments-read.yaml
@@ -15,12 +15,12 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get the attachments of a message or an appointment in Read mode.</p>
           <p><b>Required mode</b>: Item Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Get attachments</div>

--- a/samples/outlook/45-categories/work-with-categories.yaml
+++ b/samples/outlook/45-categories/work-with-categories.yaml
@@ -78,11 +78,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get, add, and remove <b>categories</b> assigned to the item.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-categories" class="ms-Button">
             <span class="ms-Button-label">Assign categories</span>

--- a/samples/outlook/45-categories/work-with-categories.yaml
+++ b/samples/outlook/45-categories/work-with-categories.yaml
@@ -109,11 +109,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/45-categories/work-with-master-categories.yaml
+++ b/samples/outlook/45-categories/work-with-master-categories.yaml
@@ -58,11 +58,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get, add, and remove <b>master categories</b> on the mailbox.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-master-categories" class="ms-Button">
               <span class="ms-Button-label">Add category to master list</span>

--- a/samples/outlook/45-categories/work-with-master-categories.yaml
+++ b/samples/outlook/45-categories/work-with-master-categories.yaml
@@ -89,11 +89,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/50-recurrence/get-recurrence-read.yaml
+++ b/samples/outlook/50-recurrence/get-recurrence-read.yaml
@@ -23,12 +23,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the item's recurrence pattern, if any.</p>
             <p><b>Required modes</b>: Appointment Attendee, Message Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
             <span class="ms-Button-label">Get the recurrence pattern</span>

--- a/samples/outlook/50-recurrence/get-recurrence-read.yaml
+++ b/samples/outlook/50-recurrence/get-recurrence-read.yaml
@@ -49,11 +49,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/50-recurrence/get-series-id.yaml
+++ b/samples/outlook/50-recurrence/get-series-id.yaml
@@ -48,11 +48,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/50-recurrence/get-series-id.yaml
+++ b/samples/outlook/50-recurrence/get-series-id.yaml
@@ -23,11 +23,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the item's <b>series ID</b>, if any.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-series-id" class="ms-Button">
             <span class="ms-Button-label">Get the series ID</span>

--- a/samples/outlook/50-recurrence/get-set-recurrence-appointment-organizer.yaml
+++ b/samples/outlook/50-recurrence/get-set-recurrence-appointment-organizer.yaml
@@ -93,11 +93,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/50-recurrence/get-set-recurrence-appointment-organizer.yaml
+++ b/samples/outlook/50-recurrence/get-set-recurrence-appointment-organizer.yaml
@@ -62,12 +62,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get and set the item's recurrence pattern, if any.</p>
             <p><b>Required mode</b>: Appointment Organizer</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
             <span class="ms-Button-label">Get the recurrence pattern</span>

--- a/samples/outlook/55-display-items/display-existing-appointment.yaml
+++ b/samples/outlook/55-display-items/display-existing-appointment.yaml
@@ -30,11 +30,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to display an existing appointment in a separate window.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <div class="ms-TextField">
             <label class="ms-Label">The itemId of item to display:</label>

--- a/samples/outlook/55-display-items/display-existing-appointment.yaml
+++ b/samples/outlook/55-display-items/display-existing-appointment.yaml
@@ -62,11 +62,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-      office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-      office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+      office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+      office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
       core-js@2.4.1/client/core.min.js
       @types/core-js

--- a/samples/outlook/55-display-items/display-existing-message.yaml
+++ b/samples/outlook/55-display-items/display-existing-message.yaml
@@ -30,11 +30,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to display an existing message in a separate window.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <div class="ms-TextField">
             <label class="ms-Label">The itemId of item to display:</label>

--- a/samples/outlook/55-display-items/display-existing-message.yaml
+++ b/samples/outlook/55-display-items/display-existing-message.yaml
@@ -62,11 +62,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-      office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-      office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+      office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+      office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
       core-js@2.4.1/client/core.min.js
       @types/core-js

--- a/samples/outlook/55-display-items/display-new-appointment.yaml
+++ b/samples/outlook/55-display-items/display-new-appointment.yaml
@@ -53,12 +53,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to display a new appointment and populate attendees, location, body, and a few other
                 properties.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="run" class="ms-Button">
             <span class="ms-Button-label">Display new appointment</span>

--- a/samples/outlook/55-display-items/display-new-appointment.yaml
+++ b/samples/outlook/55-display-items/display-new-appointment.yaml
@@ -82,11 +82,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/55-display-items/display-new-message.yaml
+++ b/samples/outlook/55-display-items/display-new-message.yaml
@@ -53,11 +53,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to display a new message, populate recipients, subject, and body, and add an inline image attachment.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="run" class="ms-Button">
                 <span class="ms-Button-label">Display new message</span>

--- a/samples/outlook/55-display-items/display-new-message.yaml
+++ b/samples/outlook/55-display-items/display-new-message.yaml
@@ -81,11 +81,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/55-display-items/display-reply-forms.yaml
+++ b/samples/outlook/55-display-items/display-reply-forms.yaml
@@ -39,11 +39,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create reply or reply-all messages and populate the body of the reply.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="display-reply-form" class="ms-Button">
                <div class="ms-Button-label">Display reply form</div>

--- a/samples/outlook/55-display-items/display-reply-forms.yaml
+++ b/samples/outlook/55-display-items/display-reply-forms.yaml
@@ -74,11 +74,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/55-display-items/display-reply-with-attachments.yaml
+++ b/samples/outlook/55-display-items/display-reply-with-attachments.yaml
@@ -47,11 +47,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create a reply message and add an inline image attachment and an item attachment.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="run" class="ms-Button">
                 <span class="ms-Button-label">Create a reply</span>

--- a/samples/outlook/55-display-items/display-reply-with-attachments.yaml
+++ b/samples/outlook/55-display-items/display-reply-with-attachments.yaml
@@ -75,11 +75,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/60-sensitivity-label/sensitivity-label.yaml
+++ b/samples/outlook/60-sensitivity-label/sensitivity-label.yaml
@@ -88,11 +88,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/60-sensitivity-label/sensitivity-label.yaml
+++ b/samples/outlook/60-sensitivity-label/sensitivity-label.yaml
@@ -59,12 +59,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get and set the sensitivity label on a message or appointment being composed. To learn more about the sensitivity label API, see <a href="https://learn.microsoft.com/office/dev/add-ins/outlook/sensitivity-label" target="_blank">Manage the sensitivity label of your message or appointment in compose mode</a>.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-sensitivity-label" class="ms-Button">
               <span class="ms-Button-label">Get sensitivity label</span>

--- a/samples/outlook/60-sensitivity-label/sensitivity-labels-catalog.yaml
+++ b/samples/outlook/60-sensitivity-label/sensitivity-labels-catalog.yaml
@@ -42,12 +42,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to determine if sensitivity labels are enabled on the mailbox and retrieves all available labels from the catalog. To learn more about the sensitivity label API, see <a href="https://learn.microsoft.com/office/dev/add-ins/outlook/sensitivity-label" target="_blank">Manage the sensitivity label of your message or appointment in compose mode</a>.</p>
              <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-sensitivity-labels-enabled" class="ms-Button">
               <span class="ms-Button-label">Sensitivity labels catalog enabled</span>

--- a/samples/outlook/60-sensitivity-label/sensitivity-labels-catalog.yaml
+++ b/samples/outlook/60-sensitivity-label/sensitivity-labels-catalog.yaml
@@ -71,11 +71,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/65-delegates-and-shared-folders/get-shared-properties.yaml
+++ b/samples/outlook/65-delegates-and-shared-folders/get-shared-properties.yaml
@@ -54,11 +54,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/65-delegates-and-shared-folders/get-shared-properties.yaml
+++ b/samples/outlook/65-delegates-and-shared-folders/get-shared-properties.yaml
@@ -23,7 +23,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to identify if the current mail item is in a shared folder or shared mailbox. This is done
                 by getting the item's shared properties.</p>
             <p><b>Required mode</b>: Compose, Read</p>
@@ -33,7 +33,7 @@ template:
                     target="_blank">Implement shared folders and shared mailbox scenarios in an Outlook add-in</a>.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out on a message or appointment from a shared folder or shared mailbox.</h3>
             <button id="get" class="ms-Button">
                     <div class="ms-Button-label">Get properties</div>

--- a/samples/outlook/70-mime-headers/get-internet-headers-message-read.yaml
+++ b/samples/outlook/70-mime-headers/get-internet-headers-message-read.yaml
@@ -62,11 +62,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/70-mime-headers/get-internet-headers-message-read.yaml
+++ b/samples/outlook/70-mime-headers/get-internet-headers-message-read.yaml
@@ -37,11 +37,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get internet headers on a message in Read mode.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="run" class="ms-Button">
             <span class="ms-Button-label">Run</span>

--- a/samples/outlook/70-mime-headers/manage-custom-internet-headers-message-compose.yaml
+++ b/samples/outlook/70-mime-headers/manage-custom-internet-headers-message-compose.yaml
@@ -93,11 +93,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/70-mime-headers/manage-custom-internet-headers-message-compose.yaml
+++ b/samples/outlook/70-mime-headers/manage-custom-internet-headers-message-compose.yaml
@@ -62,11 +62,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set, get, and remove custom internet headers on a message in Compose mode.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set-custom-headers" class="ms-Button">
               <span class="ms-Button-label">Set custom headers</span>

--- a/samples/outlook/75-regex-matches/contextual.yaml
+++ b/samples/outlook/75-regex-matches/contextual.yaml
@@ -41,7 +41,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get regex matches.</p>
             <p><b>Note</b>: Contextual add-ins only support the use of an XML manifest. This feature isn't supported when your
                 add-in uses a
@@ -51,7 +51,7 @@ template:
             <p><b>Required mode</b>: Item Read, contextual add-in</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p><b>Tip</b>: Try this out as a <a target="_blank"
                     href="https://learn.microsoft.com/outlook/add-ins/contextual-outlook-add-ins">contextual add-in</a>.</p>
             <button id="getRegExMatches" class="ms-Button">

--- a/samples/outlook/75-regex-matches/contextual.yaml
+++ b/samples/outlook/75-regex-matches/contextual.yaml
@@ -79,11 +79,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-attendee.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-attendee.yaml
@@ -72,11 +72,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-attendee.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-attendee.yaml
@@ -43,7 +43,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample uses Exchange Web Services (EWS) to get an appointment's iCalUId value if the user is an attendee.</p>
           <p><b>Important</b>: Exchange user identity and callback tokens are only supported in Exchange on-premises environments.
             In Exchange Online environments, use <a href="https://learn.microsoft.com/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in" target="_blank">nested app authentication (NAA)</a>
@@ -51,7 +51,7 @@ template:
           </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Get iCalUId property</div>

--- a/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-organizer.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-organizer.yaml
@@ -76,11 +76,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-organizer.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/get-icaluid-as-organizer.yaml
@@ -50,7 +50,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample uses Exchange Web Services (EWS) to get an appointment's iCalUId value if the user is the organizer.</p>
           <p><b>Important</b>: Exchange user identity and callback tokens are only supported in Exchange on-premises environments.
             In Exchange Online environments, use <a href="https://learn.microsoft.com/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in" target="_blank">nested app authentication (NAA)</a>

--- a/samples/outlook/85-tokens-and-service-calls/ids-and-urls.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/ids-and-urls.yaml
@@ -55,11 +55,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/85-tokens-and-service-calls/ids-and-urls.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/ids-and-urls.yaml
@@ -26,7 +26,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to retrieve the EWS endpoint URL and item IDs, and convert item IDs for different protocols.</p>
           <p><b>Important</b>: Exchange user identity and callback tokens are only supported in Exchange on-premises environments.
             In Exchange Online environments, use <a href="https://learn.microsoft.com/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in" target="_blank">nested app authentication (NAA)</a>
@@ -34,7 +34,7 @@ template:
           </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Run</div>

--- a/samples/outlook/85-tokens-and-service-calls/make-ews-request-async.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/make-ews-request-async.yaml
@@ -32,7 +32,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get a message using EWS, without any back-end code.</p>
           <p><b>Important</b>: This API is only supported in Exchange on-premises environments.
             In Exchange Online environments, use <a href="https://learn.microsoft.com/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in" target="_blank">nested app authentication (NAA)</a>
@@ -40,7 +40,7 @@ template:
           </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Run</div>

--- a/samples/outlook/85-tokens-and-service-calls/make-ews-request-async.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/make-ews-request-async.yaml
@@ -61,11 +61,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/85-tokens-and-service-calls/send-message-using-make-ews-request-async.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/send-message-using-make-ews-request-async.yaml
@@ -35,7 +35,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to send a message using EWS, without any back-end code.</p>
           <p><b>Important</b>: This API is only supported in Exchange on-premises environments.
             In Exchange Online environments, use <a href="https://learn.microsoft.com/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in" target="_blank">nested app authentication (NAA)</a>
@@ -43,7 +43,7 @@ template:
           </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Run</div>

--- a/samples/outlook/85-tokens-and-service-calls/send-message-using-make-ews-request-async.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/send-message-using-make-ews-request-async.yaml
@@ -64,11 +64,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/85-tokens-and-service-calls/user-callback-token.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/user-callback-token.yaml
@@ -52,11 +52,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/85-tokens-and-service-calls/user-callback-token.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/user-callback-token.yaml
@@ -22,7 +22,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get a callback token to call Outlook services from an add-in's backend service.</p>
           <p><b>Important</b>: Exchange user identity and callback tokens are only supported in Exchange on-premises environments.
             Additionally, the Outlook REST v2.0 endpoint has been deprecated. Use
@@ -31,7 +31,7 @@ template:
           </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Get token</div>

--- a/samples/outlook/85-tokens-and-service-calls/user-identity-token.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/user-identity-token.yaml
@@ -22,7 +22,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get a user identity token to use in authentication flows.</p>
           <p><b>Important</b>: This API is only supported in Exchange on-premises environments.
             In Exchange Online environments, use <a href="https://learn.microsoft.com/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in" target="_blank">nested app authentication (NAA)</a>
@@ -30,7 +30,7 @@ template:
           </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="run" class="ms-Button">
             <div class="ms-Button-label">Get token</div>

--- a/samples/outlook/85-tokens-and-service-calls/user-identity-token.yaml
+++ b/samples/outlook/85-tokens-and-service-calls/user-identity-token.yaml
@@ -51,11 +51,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/delay-message-delivery.yaml
+++ b/samples/outlook/90-other-item-apis/delay-message-delivery.yaml
@@ -65,12 +65,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample gets and sets the delivery date and time of a message in compose mode. To learn more about this API, see <a href="https://learn.microsoft.com/office/dev/add-ins/outlook/delay-delivery" target="_blank">Manage the delivery date and time of a message</a>.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
                 <button id="get-date" class="ms-Button">

--- a/samples/outlook/90-other-item-apis/delay-message-delivery.yaml
+++ b/samples/outlook/90-other-item-apis/delay-message-delivery.yaml
@@ -109,11 +109,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-add-remove-enhancedlocation-appointment.yaml
+++ b/samples/outlook/90-other-item-apis/get-add-remove-enhancedlocation-appointment.yaml
@@ -107,11 +107,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-add-remove-enhancedlocation-appointment.yaml
+++ b/samples/outlook/90-other-item-apis/get-add-remove-enhancedlocation-appointment.yaml
@@ -73,11 +73,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the location of an appointment.</p>
             <p><b>Required modes</b>: Appointment Organizer, Appointment Attendee</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
             <div class="ms-Button-label">Get locations</div>

--- a/samples/outlook/90-other-item-apis/get-conversation-id-message.yaml
+++ b/samples/outlook/90-other-item-apis/get-conversation-id-message.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-conversation-id-message.yaml
+++ b/samples/outlook/90-other-item-apis/get-conversation-id-message.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the conversation ID of a message.</p>
             <p><b>Required modes</b>: Message Compose, Message Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get conversation ID</div>

--- a/samples/outlook/90-other-item-apis/get-conversation-index.yaml
+++ b/samples/outlook/90-other-item-apis/get-conversation-index.yaml
@@ -55,11 +55,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-conversation-index.yaml
+++ b/samples/outlook/90-other-item-apis/get-conversation-index.yaml
@@ -29,12 +29,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the Base64-encoded position of the current message in a conversation thread.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-conversation-index" class="ms-Button">
             <span class="ms-Button-label">Get position in conversation thread</span>

--- a/samples/outlook/90-other-item-apis/get-date-time-created-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-date-time-created-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-date-time-created-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-date-time-created-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the creation date and time of an item in Read mode.</p>
             <p><b>Required modes</b>: Appointment Attendee, Message Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get creation date and time</div>

--- a/samples/outlook/90-other-item-apis/get-date-time-modified-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-date-time-modified-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-date-time-modified-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-date-time-modified-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the last-modified date and time of an item in Read mode.</p>
             <p><b>Required modes</b>: Appointment Attendee, Message Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get last-modified date and time</div>

--- a/samples/outlook/90-other-item-apis/get-diagnostic-information.yaml
+++ b/samples/outlook/90-other-item-apis/get-diagnostic-information.yaml
@@ -36,12 +36,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get a mailbox's diagnostic information.</p>
             <p><b>Required mode</b>: Compose, Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-diagnostics" class="ms-Button">
             <span class="ms-Button-label">Get diagnostics</span>

--- a/samples/outlook/90-other-item-apis/get-diagnostic-information.yaml
+++ b/samples/outlook/90-other-item-apis/get-diagnostic-information.yaml
@@ -62,11 +62,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-eml-format.yaml
+++ b/samples/outlook/90-other-item-apis/get-eml-format.yaml
@@ -22,12 +22,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the Base64-encoded EML format of a message in read mode.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-eml-format" class="ms-Button">
             <span class="ms-Button-label">Get Base64-encoded EML format</span>

--- a/samples/outlook/90-other-item-apis/get-eml-format.yaml
+++ b/samples/outlook/90-other-item-apis/get-eml-format.yaml
@@ -48,11 +48,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-end-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-end-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-end-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-end-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the end date and time of an item in Read mode.</p>
             <p><b>Required modes</b>: Appointment Attendee, Message Read (meeting request)</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get end date and time</div>

--- a/samples/outlook/90-other-item-apis/get-in-reply-to.yaml
+++ b/samples/outlook/90-other-item-apis/get-in-reply-to.yaml
@@ -22,12 +22,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the ID of the message being replied to by the current message.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-in-reply-to" class="ms-Button">
                 <span class="ms-Button-label">Get the ID</span>

--- a/samples/outlook/90-other-item-apis/get-in-reply-to.yaml
+++ b/samples/outlook/90-other-item-apis/get-in-reply-to.yaml
@@ -48,11 +48,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-internet-message-id-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-internet-message-id-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-internet-message-id-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-internet-message-id-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the internet message ID of a message in Read mode.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get internet message ID</div>

--- a/samples/outlook/90-other-item-apis/get-item-class-async.yaml
+++ b/samples/outlook/90-other-item-apis/get-item-class-async.yaml
@@ -50,11 +50,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-item-class-async.yaml
+++ b/samples/outlook/90-other-item-apis/get-item-class-async.yaml
@@ -24,12 +24,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to get the Exchange Web Services (EWS) item class of the current message being composed.</p>
             <p><b>Required mode</b>: Message Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-item-class-async" class="ms-Button">
             <span class="ms-Button-label">Get the item class</span>

--- a/samples/outlook/90-other-item-apis/get-item-class-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-item-class-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-item-class-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-item-class-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the item class of an item in Read mode.</p>
             <p><b>Required mode</b>: Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get item class</div>

--- a/samples/outlook/90-other-item-apis/get-item-type.yaml
+++ b/samples/outlook/90-other-item-apis/get-item-type.yaml
@@ -47,11 +47,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-item-type.yaml
+++ b/samples/outlook/90-other-item-apis/get-item-type.yaml
@@ -23,10 +23,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the item type.</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get item type</div>

--- a/samples/outlook/90-other-item-apis/get-location-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-location-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-location-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-location-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the location of an item in Read mode.</p>
             <p><b>Required modes</b>: Appointment Attendee, Message Read (meeting request)</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get location</div>

--- a/samples/outlook/90-other-item-apis/get-message-properties.yaml
+++ b/samples/outlook/90-other-item-apis/get-message-properties.yaml
@@ -69,11 +69,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-message-properties.yaml
+++ b/samples/outlook/90-other-item-apis/get-message-properties.yaml
@@ -41,11 +41,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the properties of multiple selected messages.</p>
             <p><b>Required mode</b>: Message Compose, Message Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <ol>
                 <li><p>Turn on the Reading Pane in Outlook. For guidance, see <a href="https://support.microsoft.com/office/2fd687ed-7fc4-4ae3-8eab-9f9b8c6d53f0" target="_blank">Use and configure the Reading Pane to preview messages</a>.</p></li>

--- a/samples/outlook/90-other-item-apis/get-normalized-subject-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-normalized-subject-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-normalized-subject-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-normalized-subject-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the normalized subject of an item in Read mode.</p>
             <p><b>Required modes</b>: Appointment Attendee, Message Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get normalized subject</div>

--- a/samples/outlook/90-other-item-apis/get-set-end-appointment-organizer.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-end-appointment-organizer.yaml
@@ -69,11 +69,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-set-end-appointment-organizer.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-end-appointment-organizer.yaml
@@ -41,11 +41,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the end date and time of an appointment in Compose mode.</p>
             <p><b>Required mode</b>: Appointment Organizer</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set" class="ms-Button">
               <div class="ms-Button-label">Set end date and time</div>

--- a/samples/outlook/90-other-item-apis/get-set-location-appointment-organizer.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-location-appointment-organizer.yaml
@@ -33,11 +33,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the location of an appointment in Compose mode.</p>
             <p><b>Required mode</b>: Appointment Organizer</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set" class="ms-Button">
               <div class="ms-Button-label">Set location</div>

--- a/samples/outlook/90-other-item-apis/get-set-location-appointment-organizer.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-location-appointment-organizer.yaml
@@ -61,11 +61,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-set-sensitivity-level.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-sensitivity-level.yaml
@@ -35,7 +35,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the sensitivity level of an appointment being composed.
                 <p>
                     <b>Required mode</b>: Appointment Organizer
@@ -43,7 +43,7 @@ template:
             </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <button id="getSensitivity" class="ms-Button">
             <div class="ms-Button-label">Get sensitivity level</div>
         </button>

--- a/samples/outlook/90-other-item-apis/get-set-sensitivity-level.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-sensitivity-level.yaml
@@ -66,11 +66,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-set-start-appointment-organizer.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-start-appointment-organizer.yaml
@@ -34,11 +34,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the start date and time of an appointment in Compose mode.</p>
             <p><b>Required mode</b>: Appointment Organizer</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set" class="ms-Button">
               <div class="ms-Button-label">Set start date and time</div>

--- a/samples/outlook/90-other-item-apis/get-set-start-appointment-organizer.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-start-appointment-organizer.yaml
@@ -62,11 +62,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-set-subject-compose.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-subject-compose.yaml
@@ -61,11 +61,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-set-subject-compose.yaml
+++ b/samples/outlook/90-other-item-apis/get-set-subject-compose.yaml
@@ -33,11 +33,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to set and get the subject of an item in Compose mode.</p>
           <p><b>Required mode</b>: Compose</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="set" class="ms-Button">
             <div class="ms-Button-label">Set subject</div>

--- a/samples/outlook/90-other-item-apis/get-start-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-start-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the start date and time of an item in Read mode.</p>
             <p><b>Required modes</b>: Appointment Attendee, Message Read (meeting request)</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get start date and time</div>

--- a/samples/outlook/90-other-item-apis/get-start-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-start-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-subject-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-subject-read.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/get-subject-read.yaml
+++ b/samples/outlook/90-other-item-apis/get-subject-read.yaml
@@ -15,11 +15,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get the subject of an item in Read mode.</p>
             <p><b>Required mode</b>: Read</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get" class="ms-Button">
               <div class="ms-Button-label">Get subject</div>

--- a/samples/outlook/90-other-item-apis/item-id-compose.yaml
+++ b/samples/outlook/90-other-item-apis/item-id-compose.yaml
@@ -49,11 +49,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/item-id-compose.yaml
+++ b/samples/outlook/90-other-item-apis/item-id-compose.yaml
@@ -22,12 +22,12 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get an item ID in compose mode.</p>
           <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <p>Before you can get the item ID, you must first save the mail item.</p>
           <button id="run" class="ms-Button">

--- a/samples/outlook/90-other-item-apis/session-data-apis.yaml
+++ b/samples/outlook/90-other-item-apis/session-data-apis.yaml
@@ -68,14 +68,14 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to set, get, get all, remove, and clear session data in compose mode.
                 <p>
                     <b>Required mode</b>: Compose
                 </p>
             </p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <button id="setSessionData" class="ms-Button">
             <div class="ms-Button-label">Set SessionData</div>
         </button>

--- a/samples/outlook/90-other-item-apis/session-data-apis.yaml
+++ b/samples/outlook/90-other-item-apis/session-data-apis.yaml
@@ -107,10 +107,10 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
     core-js@2.4.1/client/core.min.js
     @types/core-js
     jquery@3.1.1

--- a/samples/outlook/90-other-item-apis/set-selected-data.yaml
+++ b/samples/outlook/90-other-item-apis/set-selected-data.yaml
@@ -48,11 +48,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/set-selected-data.yaml
+++ b/samples/outlook/90-other-item-apis/set-selected-data.yaml
@@ -21,12 +21,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to replace the selected text in the item body or subject/title.</p>
             <p><b>Required mode</b>: Compose</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Select text in the item body or subject then push the <b>Replace selected text</b> button.</p>
             <button id="set-selected-data" class="ms-Button">

--- a/samples/outlook/90-other-item-apis/work-with-client-signatures.yaml
+++ b/samples/outlook/90-other-item-apis/work-with-client-signatures.yaml
@@ -137,11 +137,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/90-other-item-apis/work-with-client-signatures.yaml
+++ b/samples/outlook/90-other-item-apis/work-with-client-signatures.yaml
@@ -91,7 +91,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to check if the client signature is enabled, disable the client signature, get the compose
                 type, and set the signature.
                 <p>
@@ -100,7 +100,7 @@ template:
             </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="isClientSignatureEnabled" class="ms-Button">
                 <div class="ms-Button-label">isClientSignatureEnabled</div>

--- a/samples/outlook/99-preview-apis/get-set-isalldayevent.yaml
+++ b/samples/outlook/99-preview-apis/get-set-isalldayevent.yaml
@@ -66,8 +66,8 @@ libraries: |
     https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
     @types/office-js-preview
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/99-preview-apis/get-set-isalldayevent.yaml
+++ b/samples/outlook/99-preview-apis/get-set-isalldayevent.yaml
@@ -32,7 +32,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get and set the isAllDayEvent property of an appointment being composed.
                 <p>
                     <b>Required mode</b>: Appointment Organizer
@@ -40,7 +40,7 @@ template:
             </p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <button id="getIsAllDayEvent" class="ms-Button">
             <div class="ms-Button-label">Get isAllDayEvent</div>
         </button>

--- a/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml
+++ b/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml
@@ -44,13 +44,13 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">This sample shows how to temporarily set the content displayed in the body or subject of a
                 message in read mode.</p>
             <p><b>Required mode</b>: Message Read</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <div class="ms-TextField">
                 <label class="ms-Label">Enter text to temporarily display in the body:</label>

--- a/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml
+++ b/samples/outlook/99-preview-apis/set-displayed-body-subject.yaml
@@ -87,8 +87,8 @@ libraries: |
     https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
     @types/office-js-preview
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/outlook/default.yaml
+++ b/samples/outlook/default.yaml
@@ -33,11 +33,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/basics/basic-api-call-js.yaml
+++ b/samples/powerpoint/basics/basic-api-call-js.yaml
@@ -60,11 +60,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/basics/basic-api-call-js.yaml
+++ b/samples/powerpoint/basics/basic-api-call-js.yaml
@@ -39,7 +39,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample executes a code snippet that adds a text box to the first slide in the presentation.
         </section>
         <button id="run" class="ms-Button">

--- a/samples/powerpoint/basics/basic-api-call-ts.yaml
+++ b/samples/powerpoint/basics/basic-api-call-ts.yaml
@@ -60,11 +60,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/basics/basic-api-call-ts.yaml
+++ b/samples/powerpoint/basics/basic-api-call-ts.yaml
@@ -39,7 +39,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample executes a code snippet that adds a text box to the first slide in the presentation.
         </section>
         <button id="run" class="ms-Button">

--- a/samples/powerpoint/basics/basic-common-api-call.yaml
+++ b/samples/powerpoint/basics/basic-common-api-call.yaml
@@ -40,11 +40,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/default.yaml
+++ b/samples/powerpoint/default.yaml
@@ -38,11 +38,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/document/create-presentation.yaml
+++ b/samples/powerpoint/document/create-presentation.yaml
@@ -42,11 +42,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create a new, empty presentation and how to create a new presentation by copying an existing one.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p><b>Create empty presentation</b></p>
             <button id="create-new-blank-presentation" class="ms-Button">

--- a/samples/powerpoint/document/create-presentation.yaml
+++ b/samples/powerpoint/document/create-presentation.yaml
@@ -73,11 +73,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/images/insert-image.yaml
+++ b/samples/powerpoint/images/insert-image.yaml
@@ -54,11 +54,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/images/insert-image.yaml
+++ b/samples/powerpoint/images/insert-image.yaml
@@ -32,7 +32,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>Insert an image into the current slide.</p>
         </section>
 

--- a/samples/powerpoint/images/insert-svg.yaml
+++ b/samples/powerpoint/images/insert-svg.yaml
@@ -58,11 +58,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/images/insert-svg.yaml
+++ b/samples/powerpoint/images/insert-svg.yaml
@@ -33,11 +33,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to insert an SVG image using an XML string as the source.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="insert" class="ms-Button">
                 <span class="ms-Button-label">Insert new SVG</span>

--- a/samples/powerpoint/preview-apis/manage-hyperlinks.yaml
+++ b/samples/powerpoint/preview-apis/manage-hyperlinks.yaml
@@ -35,11 +35,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">Demonstrates how to get the hyperlinks located in a slide.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>First, add at least one hyperlink to a slide then select at least one slide.</p>
             <button id="get-hyperlinks" class="ms-Button">

--- a/samples/powerpoint/preview-apis/manage-hyperlinks.yaml
+++ b/samples/powerpoint/preview-apis/manage-hyperlinks.yaml
@@ -64,8 +64,8 @@ libraries: |
     https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
     @types/office-js-preview
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/scenarios/searches-wikipedia-api.yaml
+++ b/samples/powerpoint/scenarios/searches-wikipedia-api.yaml
@@ -222,11 +222,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/scenarios/searches-wikipedia-api.yaml
+++ b/samples/powerpoint/scenarios/searches-wikipedia-api.yaml
@@ -181,15 +181,15 @@ script:
     language: typescript
 template:
     content: |-
-        <header class="ms-welcome__header ms-bgColor-neutralLighter" style="text-align: center">
+        <header class="ms-Fabric ms-welcome__header ms-bgColor-neutralLighter" style="text-align: center">
           <h1 class="ms-font-su">Search Wikipedia</h1>
         </header>
 
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to query external API (Wikipedia) with the text currently selected in the presentation.</p>
          </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Try it out</h3>
           <p>Select any text in the presentation and press <b>Search</b> to see related Wikipedia entries.</p>
           <p>The search result will be provided by Wikipedia API. </p>
@@ -202,7 +202,7 @@ template:
           </ol>
         </section>
 
-        <section class="sample ms-font-m">
+        <section class="ms-Fabric sample ms-font-m">
           <h3>Result</h3>
           <div id="result">
           </div>

--- a/samples/powerpoint/shapes/get-set-shapes.yaml
+++ b/samples/powerpoint/shapes/get-set-shapes.yaml
@@ -214,11 +214,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/shapes/get-set-shapes.yaml
+++ b/samples/powerpoint/shapes/get-set-shapes.yaml
@@ -177,11 +177,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get selected shapes, and how to select and change specific shapes.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
         <button id="createShapes" class="ms-Button"><span class="ms-Button-label">Create shapes</span></button>
         <br><button id="getSelectedShapes" class="ms-Button"><span class="ms-Button-label">Get selected shapes</span></button>

--- a/samples/powerpoint/shapes/get-shapes-by-type.yaml
+++ b/samples/powerpoint/shapes/get-shapes-by-type.yaml
@@ -96,11 +96,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how select and change shapes based on their types.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Setup</h3>
           <p>Create some shapes in a new, blank presentation.</p>
           <p />

--- a/samples/powerpoint/shapes/get-shapes-by-type.yaml
+++ b/samples/powerpoint/shapes/get-shapes-by-type.yaml
@@ -135,11 +135,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/shapes/shapes.yaml
+++ b/samples/powerpoint/shapes/shapes.yaml
@@ -217,11 +217,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/shapes/shapes.yaml
+++ b/samples/powerpoint/shapes/shapes.yaml
@@ -152,11 +152,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to create, resize, move, and delete shapes.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Begin by deleting all shapes that are currently on the slide.</p>
             <p />

--- a/samples/powerpoint/slide-management/add-slides.yaml
+++ b/samples/powerpoint/slide-management/add-slides.yaml
@@ -102,11 +102,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/slide-management/add-slides.yaml
+++ b/samples/powerpoint/slide-management/add-slides.yaml
@@ -57,11 +57,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add a slide and optionally to specify the slide master and layout of the slide.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>On the <b>Home</b> ribbon, open the <b>New Slide</b> drop down menu to see the slide masters and slide layouts in the presentation. Be sure there are at least two slide masters. To add a master, see <a
                     target="_blank"

--- a/samples/powerpoint/slide-management/get-set-slides.yaml
+++ b/samples/powerpoint/slide-management/get-set-slides.yaml
@@ -165,11 +165,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/slide-management/get-set-slides.yaml
+++ b/samples/powerpoint/slide-management/get-set-slides.yaml
@@ -130,11 +130,11 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to get selected slides, and how to select specific slides.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
           <button id="getSelectedSlides" class="ms-Button"><span class="ms-Button-label">Get selected slides</span></button>
           <br><button id="setSelectedSlides" class="ms-Button"><span class="ms-Button-label">Set selection to slides 2, 4, and 5</span></button>

--- a/samples/powerpoint/slide-management/get-slide-metadata.yaml
+++ b/samples/powerpoint/slide-management/get-slide-metadata.yaml
@@ -23,7 +23,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p class="ms-font-m">Demonstrates how to get slide metadata.</p>
             <p class="ms-font-m">Select one or more slides and click <b>Get slide metadata</b> to get the ID, title, and index of the slide(s).</p>
         </section>

--- a/samples/powerpoint/slide-management/get-slide-metadata.yaml
+++ b/samples/powerpoint/slide-management/get-slide-metadata.yaml
@@ -46,11 +46,11 @@ style:
         }  
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/slide-management/insert-slides.yaml
+++ b/samples/powerpoint/slide-management/insert-slides.yaml
@@ -68,11 +68,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to insert slides from another presentation into the current presentation.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <ol>

--- a/samples/powerpoint/slide-management/insert-slides.yaml
+++ b/samples/powerpoint/slide-management/insert-slides.yaml
@@ -110,11 +110,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/tags/tags.yaml
+++ b/samples/powerpoint/tags/tags.yaml
@@ -206,11 +206,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/powerpoint/tags/tags.yaml
+++ b/samples/powerpoint/tags/tags.yaml
@@ -151,10 +151,10 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>These snippets show how to use tags with the presentation and its slides and shapes.</p>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
 
             <p>1. Add several slides to the deck. Add content to each so they are visually distinct in the thumbnail pane.</p>

--- a/samples/powerpoint/text/get-set-textrange.yaml
+++ b/samples/powerpoint/text/get-set-textrange.yaml
@@ -149,10 +149,10 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           <p>This sample shows how to get selected text, and how to select specific text.</p>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <button id="getSelectedTextRange" class="ms-Button"><span class="ms-Button-label">Get selected text range</span></button>
           <br><button id="setSelectedTextRange" class="ms-Button"><span class="ms-Button-label">Selects the first 10 characters of the selected shape.</span></button>

--- a/samples/powerpoint/text/get-set-textrange.yaml
+++ b/samples/powerpoint/text/get-set-textrange.yaml
@@ -183,11 +183,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/project/basics/basic-common-api-call.yaml
+++ b/samples/project/basics/basic-common-api-call.yaml
@@ -31,11 +31,11 @@ style:
         /* Your style goes here */
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/project/default.yaml
+++ b/samples/project/default.yaml
@@ -38,11 +38,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/web/default.yaml
+++ b/samples/web/default.yaml
@@ -32,8 +32,8 @@ style:
         }
     language: css
 libraries: |
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/01-basics/basic-api-call-es5.yaml
+++ b/samples/word/01-basics/basic-api-call-es5.yaml
@@ -56,11 +56,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/01-basics/basic-api-call-es5.yaml
+++ b/samples/word/01-basics/basic-api-call-es5.yaml
@@ -35,7 +35,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample executes a code snippet that prints the selected text to the console. Make sure to enter and select text before clicking "Print selection".
         </section>
         <button id="run" class="ms-Button">

--- a/samples/word/01-basics/basic-api-call.yaml
+++ b/samples/word/01-basics/basic-api-call.yaml
@@ -57,11 +57,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/01-basics/basic-api-call.yaml
+++ b/samples/word/01-basics/basic-api-call.yaml
@@ -36,7 +36,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample executes a code snippet that prints the selected text to the console. Make sure to enter and select text before clicking "Print selection".
         </section>
         <button id="run" class="ms-Button">

--- a/samples/word/01-basics/basic-common-api-call.yaml
+++ b/samples/word/01-basics/basic-common-api-call.yaml
@@ -43,11 +43,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/01-basics/basic-common-api-call.yaml
+++ b/samples/word/01-basics/basic-common-api-call.yaml
@@ -22,7 +22,7 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample executes a code snippet that prints the selected text to the console. Make sure to enter and select text before clicking "Print selection".
         </section>
         <button id="run" class="ms-Button">

--- a/samples/word/10-content-controls/content-control-onadded-event.yaml
+++ b/samples/word/10-content-controls/content-control-onadded-event.yaml
@@ -131,11 +131,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/content-control-onadded-event.yaml
+++ b/samples/word/10-content-controls/content-control-onadded-event.yaml
@@ -90,18 +90,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onAdded event with content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">Register event handler.</span>
             <button id="register-event-handler" class="ms-Button">

--- a/samples/word/10-content-controls/content-control-ondatachanged-event.yaml
+++ b/samples/word/10-content-controls/content-control-ondatachanged-event.yaml
@@ -107,18 +107,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onDataChanged event on content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">1. Insert content controls.</span>
             <button id="insert-content-controls" class="ms-Button">

--- a/samples/word/10-content-controls/content-control-ondatachanged-event.yaml
+++ b/samples/word/10-content-controls/content-control-ondatachanged-event.yaml
@@ -149,11 +149,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/content-control-ondeleted-event.yaml
+++ b/samples/word/10-content-controls/content-control-ondeleted-event.yaml
@@ -169,11 +169,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/content-control-ondeleted-event.yaml
+++ b/samples/word/10-content-controls/content-control-ondeleted-event.yaml
@@ -124,18 +124,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onDeleted event on content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">Insert content controls.</span>
             <button id="insert-content-controls" class="ms-Button">

--- a/samples/word/10-content-controls/content-control-onentered-event.yaml
+++ b/samples/word/10-content-controls/content-control-onentered-event.yaml
@@ -107,18 +107,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onEntered event on content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">1. Insert content controls.</span>
             <button id="insert-content-controls" class="ms-Button">

--- a/samples/word/10-content-controls/content-control-onentered-event.yaml
+++ b/samples/word/10-content-controls/content-control-onentered-event.yaml
@@ -149,11 +149,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/content-control-onexited-event.yaml
+++ b/samples/word/10-content-controls/content-control-onexited-event.yaml
@@ -107,18 +107,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onExited event on content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">1. Insert content controls.</span>
             <button id="insert-content-controls" class="ms-Button">

--- a/samples/word/10-content-controls/content-control-onexited-event.yaml
+++ b/samples/word/10-content-controls/content-control-onexited-event.yaml
@@ -150,11 +150,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/content-control-onselectionchanged-event.yaml
+++ b/samples/word/10-content-controls/content-control-onselectionchanged-event.yaml
@@ -106,18 +106,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onSelectionChanged event on content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">1. Insert content controls.</span>
             <button id="insert-content-controls" class="ms-Button">

--- a/samples/word/10-content-controls/content-control-onselectionchanged-event.yaml
+++ b/samples/word/10-content-controls/content-control-onselectionchanged-event.yaml
@@ -148,11 +148,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/get-change-tracking-states.yaml
+++ b/samples/word/10-content-controls/get-change-tracking-states.yaml
@@ -118,18 +118,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to insert and delete control controls then get their change tracking state.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="turn-on-change-tracking" class="ms-Button">
             <span class="ms-Button-label">Turn on change tracking</span>

--- a/samples/word/10-content-controls/get-change-tracking-states.yaml
+++ b/samples/word/10-content-controls/get-change-tracking-states.yaml
@@ -162,11 +162,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/insert-and-change-checkbox-content-control.yaml
+++ b/samples/word/10-content-controls/insert-and-change-checkbox-content-control.yaml
@@ -182,18 +182,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to insert, change, and delete checkbox content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <span class="ms-font-m">Insert checkbox content controls on each paragraph.</span>

--- a/samples/word/10-content-controls/insert-and-change-checkbox-content-control.yaml
+++ b/samples/word/10-content-controls/insert-and-change-checkbox-content-control.yaml
@@ -235,11 +235,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/insert-and-change-content-controls.yaml
+++ b/samples/word/10-content-controls/insert-and-change-content-controls.yaml
@@ -138,11 +138,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/10-content-controls/insert-and-change-content-controls.yaml
+++ b/samples/word/10-content-controls/insert-and-change-content-controls.yaml
@@ -101,18 +101,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to insert and change content control properties.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">Insert content controls on each paragraph.</span>
             <button id="insert-controls" class="ms-Button">

--- a/samples/word/15-images/insert-and-get-pictures.yaml
+++ b/samples/word/15-images/insert-and-get-pictures.yaml
@@ -72,18 +72,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to insert and get inline pictures in a document.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="insert" class="ms-Button">
             <span class="ms-Button-label">Insert picture</span>

--- a/samples/word/15-images/insert-and-get-pictures.yaml
+++ b/samples/word/15-images/insert-and-get-pictures.yaml
@@ -107,11 +107,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/20-lists/insert-list.yaml
+++ b/samples/word/20-lists/insert-list.yaml
@@ -108,11 +108,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/20-lists/insert-list.yaml
+++ b/samples/word/20-lists/insert-list.yaml
@@ -76,18 +76,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to insert and change lists.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Add text</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="insert-list" class="ms-Button">
               <span class="ms-Button-label">Insert list</span>

--- a/samples/word/20-lists/manage-list-styles.yaml
+++ b/samples/word/20-lists/manage-list-styles.yaml
@@ -106,10 +106,10 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
     core-js@2.4.1/client/core.min.js
     @types/core-js
     jquery@3.1.1

--- a/samples/word/20-lists/manage-list-styles.yaml
+++ b/samples/word/20-lists/manage-list-styles.yaml
@@ -73,11 +73,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample shows how to get the list styles in the current document.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <button id="count" class="ms-Button">

--- a/samples/word/20-lists/organize-list.yaml
+++ b/samples/word/20-lists/organize-list.yaml
@@ -101,18 +101,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to create and organize a list.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Add text</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="insert-list" class="ms-Button">
             <span class="ms-Button-label">Insert list</span>

--- a/samples/word/20-lists/organize-list.yaml
+++ b/samples/word/20-lists/organize-list.yaml
@@ -136,11 +136,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/get-paragraph-on-insertion-point.yaml
+++ b/samples/word/25-paragraph/get-paragraph-on-insertion-point.yaml
@@ -116,11 +116,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/get-paragraph-on-insertion-point.yaml
+++ b/samples/word/25-paragraph/get-paragraph-on-insertion-point.yaml
@@ -80,18 +80,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to get the paragraph and paragraph sentences associated with the current insertion point.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
         <span class="ms-font-m">Select an insertion point in the document.</span><p>
             <button id="get-paragraph" class="ms-Button">

--- a/samples/word/25-paragraph/get-text.yaml
+++ b/samples/word/25-paragraph/get-text.yaml
@@ -96,11 +96,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/get-text.yaml
+++ b/samples/word/25-paragraph/get-text.yaml
@@ -52,7 +52,7 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample demonstrates how to get paragraph text, including hidden text and text marked for deletion.</p>
             <ul>
                 <li>How to hide selected text (only available on Windows):
@@ -68,14 +68,14 @@ template:
             </ul>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="run" class="ms-Button">
             <span class="ms-Button-label">Get text</span>

--- a/samples/word/25-paragraph/get-word-count.yaml
+++ b/samples/word/25-paragraph/get-word-count.yaml
@@ -88,18 +88,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to get the count for words and terms in the document body.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
           <h3>Set up</h3>
           <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
           <span class="ms-font-m">Get the word/term count.</span>
           <p>

--- a/samples/word/25-paragraph/get-word-count.yaml
+++ b/samples/word/25-paragraph/get-word-count.yaml
@@ -123,11 +123,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/insert-formatted-text.yaml
+++ b/samples/word/25-paragraph/insert-formatted-text.yaml
@@ -76,11 +76,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample shows how to insert basic formatted text and apply built-in styles.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-text" class="ms-Button">
               <span class="ms-Button-label">Insert formatted text</span>

--- a/samples/word/25-paragraph/insert-formatted-text.yaml
+++ b/samples/word/25-paragraph/insert-formatted-text.yaml
@@ -107,11 +107,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/insert-header-and-footer.yaml
+++ b/samples/word/25-paragraph/insert-header-and-footer.yaml
@@ -127,11 +127,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample inserts headers and footers in the document.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <p>1. Set up sample text.
             <button id="setup" class="ms-Button">
@@ -141,7 +141,7 @@ template:
                 existing headers and footers</a> for details).
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Apply to all pages</h4>
             <button id="add-header" class="ms-Button">

--- a/samples/word/25-paragraph/insert-header-and-footer.yaml
+++ b/samples/word/25-paragraph/insert-header-and-footer.yaml
@@ -185,11 +185,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/insert-in-different-locations.yaml
+++ b/samples/word/25-paragraph/insert-in-different-locations.yaml
@@ -151,11 +151,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/insert-in-different-locations.yaml
+++ b/samples/word/25-paragraph/insert-in-different-locations.yaml
@@ -107,18 +107,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates a variety of insert locations available in the API.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                   <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
           <button id="before" class="ms-Button">
               <span class="ms-Button-label">Insert before</span>

--- a/samples/word/25-paragraph/insert-line-and-page-breaks.yaml
+++ b/samples/word/25-paragraph/insert-line-and-page-breaks.yaml
@@ -60,18 +60,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to insert page and line breaks.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="line" class="ms-Button">
             <span class="ms-Button-label">Insert line break</span>

--- a/samples/word/25-paragraph/insert-line-and-page-breaks.yaml
+++ b/samples/word/25-paragraph/insert-line-and-page-breaks.yaml
@@ -95,11 +95,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/onadded-event.yaml
+++ b/samples/word/25-paragraph/onadded-event.yaml
@@ -114,11 +114,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/onadded-event.yaml
+++ b/samples/word/25-paragraph/onadded-event.yaml
@@ -76,11 +76,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onAdded event with paragraphs.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="register-event-handler" class="ms-Button">
             <span class="ms-Button-label">Register event handler</span>

--- a/samples/word/25-paragraph/onchanged-event.yaml
+++ b/samples/word/25-paragraph/onchanged-event.yaml
@@ -72,18 +72,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onChanged event with paragraphs.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add paragraphs</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="register-event-handler" class="ms-Button">
             <span class="ms-Button-label">Register event handler</span>

--- a/samples/word/25-paragraph/onchanged-event.yaml
+++ b/samples/word/25-paragraph/onchanged-event.yaml
@@ -116,11 +116,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/ondeleted-event.yaml
+++ b/samples/word/25-paragraph/ondeleted-event.yaml
@@ -116,11 +116,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/ondeleted-event.yaml
+++ b/samples/word/25-paragraph/ondeleted-event.yaml
@@ -78,18 +78,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the onDeleted event with paragraphs.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add paragraphs</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="register-event-handler" class="ms-Button">
             <span class="ms-Button-label">Register event handler</span>

--- a/samples/word/25-paragraph/paragraph-properties.yaml
+++ b/samples/word/25-paragraph/paragraph-properties.yaml
@@ -150,11 +150,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/paragraph-properties.yaml
+++ b/samples/word/25-paragraph/paragraph-properties.yaml
@@ -101,18 +101,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
         This sample demonstrates paragraph property usage.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="indent" class="ms-Button">
               <span class="ms-Button-label">Indent first paragraph</span>

--- a/samples/word/25-paragraph/search.yaml
+++ b/samples/word/25-paragraph/search.yaml
@@ -113,11 +113,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/25-paragraph/search.yaml
+++ b/samples/word/25-paragraph/search.yaml
@@ -78,18 +78,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates basic and advanced search capabilities of the API.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="basic-search" class="ms-Button">
             <span class="ms-Button-label">Basic search</span>

--- a/samples/word/30-properties/get-built-in-properties.yaml
+++ b/samples/word/30-properties/get-built-in-properties.yaml
@@ -33,11 +33,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to get the built-in properties of a Word document.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
             <button id="run" class="ms-Button">
               <span class="ms-Button-label">Get built-in properties</span>

--- a/samples/word/30-properties/get-built-in-properties.yaml
+++ b/samples/word/30-properties/get-built-in-properties.yaml
@@ -58,11 +58,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/30-properties/read-write-custom-document-properties.yaml
+++ b/samples/word/30-properties/read-write-custom-document-properties.yaml
@@ -85,11 +85,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/30-properties/read-write-custom-document-properties.yaml
+++ b/samples/word/30-properties/read-write-custom-document-properties.yaml
@@ -54,11 +54,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to insert custom document properties of different data types and how to read them.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
         <h3>Try it out</h3>
             <button id="number" class="ms-Button">
                         <span class="ms-Button-label">Add 'numeric' property</span>

--- a/samples/word/35-ranges/compare-location.yaml
+++ b/samples/word/35-ranges/compare-location.yaml
@@ -120,11 +120,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/35-ranges/compare-location.yaml
+++ b/samples/word/35-ranges/compare-location.yaml
@@ -80,18 +80,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to compare locations of ranges.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample text</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Compare location of first paragraph with location of second paragraph</h4>
             <button id="compare" class="ms-Button">

--- a/samples/word/35-ranges/scroll-to-range.yaml
+++ b/samples/word/35-ranges/scroll-to-range.yaml
@@ -60,18 +60,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to scroll to a range.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="scroll" class="ms-Button">
               <span class="ms-Button-label">Scroll with selection</span>

--- a/samples/word/35-ranges/scroll-to-range.yaml
+++ b/samples/word/35-ranges/scroll-to-range.yaml
@@ -95,11 +95,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/35-ranges/split-words-of-first-paragraph.yaml
+++ b/samples/word/35-ranges/split-words-of-first-paragraph.yaml
@@ -95,11 +95,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/35-ranges/split-words-of-first-paragraph.yaml
+++ b/samples/word/35-ranges/split-words-of-first-paragraph.yaml
@@ -63,18 +63,18 @@ script:
     language: typescript
 template:
     content: |
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
            This sample demonstrates splitting and traversing ranges.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample text</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="highlight" class="ms-Button">
                 <span class="ms-Button-label">Highlight word by word</span>

--- a/samples/word/40-tables/manage-custom-style.yaml
+++ b/samples/word/40-tables/manage-custom-style.yaml
@@ -332,14 +332,14 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample demonstrates how to manage a custom table style and use Document.importStylesFromJson.
             </p>
             <p><b>Important</b>: Some TableStyle properties are currently in preview. If this snippet doesn't work, try using Word
                 on a different platform.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Add a new table style</h4>
             <p>Name the style using letters. Can include digits. Examples: NewName, newname1</p>
@@ -363,7 +363,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h4>Update custom style</h4> <label class="msLabel">Alignment:</label>
             <select id="alignment">
                 <option>Centered</option>    
@@ -379,7 +379,7 @@ template:
               </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <label style="msLabel">allowBreakAcrossPage:</label>
             <select id="allow-break-across-page">
               <option>false</option>    
@@ -391,7 +391,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <label class="msLabel">Top cell margin:</label>
             <input id="top-cell-margin" type="text" />
             </br>
@@ -400,7 +400,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <label class="msLabel">Bottom cell margin:</label>
             <input id="bottom-cell-margin" type="text" />
             <br>
@@ -409,7 +409,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <label class="msLabel">Left cell margin:</label>
             <input id="left-cell-margin" type="text" />
             <br>
@@ -418,7 +418,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <label class="msLabel">Right cell margin:</label>
             <input id="right-cell-margin" type="text" />
             <br>
@@ -427,7 +427,7 @@ template:
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <label class="msLabel">Cell spacing:</label>
             <input id="cell-spacing" type="text" />
             <br>
@@ -436,7 +436,7 @@ template:
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h4>Delete custom style</h4>
             <label style="margin-left: 20px">Style name:</label>
             <input id="style-name-to-delete"/>
@@ -446,7 +446,7 @@ template:
             </button>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h4>Import styles from JSON string</h4>
             <button id="import-styles-from-json" class="ms-Button margin">
                     <span class="ms-Button-label">Import</span>

--- a/samples/word/40-tables/manage-custom-style.yaml
+++ b/samples/word/40-tables/manage-custom-style.yaml
@@ -472,11 +472,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/40-tables/manage-formatting.yaml
+++ b/samples/word/40-tables/manage-formatting.yaml
@@ -167,18 +167,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample shows how to get various formatting details about a table, a table row, and a table cell, including
             borders, alignment, and cell padding.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Add table</span>
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Table formatting</h4>
             <p>

--- a/samples/word/40-tables/manage-formatting.yaml
+++ b/samples/word/40-tables/manage-formatting.yaml
@@ -232,11 +232,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/40-tables/table-cell-access.yaml
+++ b/samples/word/40-tables/table-cell-access.yaml
@@ -49,18 +49,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
           This sample demonstrates how to get a cell from a table.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add table</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="run" class="ms-Button">
                 <span class="ms-Button-label">Get cell content</span>

--- a/samples/word/40-tables/table-cell-access.yaml
+++ b/samples/word/40-tables/table-cell-access.yaml
@@ -81,11 +81,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/compare-documents.yaml
+++ b/samples/word/50-document/compare-documents.yaml
@@ -70,11 +70,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/compare-documents.yaml
+++ b/samples/word/50-document/compare-documents.yaml
@@ -43,11 +43,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to compare two documents: the current one and a specified external one.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <label>File (with absolute path): </label>
             <input id="filePath">

--- a/samples/word/50-document/get-external-styles.yaml
+++ b/samples/word/50-document/get-external-styles.yaml
@@ -80,10 +80,10 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
     core-js@2.4.1/client/core.min.js
     @types/core-js
     jquery@3.1.1

--- a/samples/word/50-document/get-external-styles.yaml
+++ b/samples/word/50-document/get-external-styles.yaml
@@ -49,11 +49,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to get styles from an external document.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
           <h3>Try it out</h3>
             <p>Select a Word document to get its style info.</p>
             <form>

--- a/samples/word/50-document/insert-external-document.yaml
+++ b/samples/word/50-document/insert-external-document.yaml
@@ -77,11 +77,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to insert the body text from an external document into the current document.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Select a Word document.</p>
             <form>

--- a/samples/word/50-document/insert-external-document.yaml
+++ b/samples/word/50-document/insert-external-document.yaml
@@ -113,11 +113,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/insert-section-breaks.yaml
+++ b/samples/word/50-document/insert-section-breaks.yaml
@@ -90,11 +90,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample shows how to insert sections in the document.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample text</span>
@@ -102,7 +102,7 @@ template:
           <p>You should also show the formatting marks to see the section indicators. To learn more, refer to <a target="_blank" href="https://support.microsoft.com/office/84a53213-5d02-404a-b022-09cae1a3958b">Show or hide tab marks in Word</a></p> 
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-sectionNext" class="ms-Button">
               <span class="ms-Button-label">Insert on next page</span>

--- a/samples/word/50-document/insert-section-breaks.yaml
+++ b/samples/word/50-document/insert-section-breaks.yaml
@@ -132,11 +132,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-annotations.yaml
+++ b/samples/word/50-document/manage-annotations.yaml
@@ -299,18 +299,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample demonstrates how to manage annotations and use annotation events.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="register-event-handlers" class="ms-Button">
                 <span class="ms-Button-label">Register event handlers</span>

--- a/samples/word/50-document/manage-annotations.yaml
+++ b/samples/word/50-document/manage-annotations.yaml
@@ -355,11 +355,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-body.yaml
+++ b/samples/word/50-document/manage-body.yaml
@@ -410,11 +410,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-body.yaml
+++ b/samples/word/50-document/manage-body.yaml
@@ -334,18 +334,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample shows how to manage the content of the document body.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
                 <span class="ms-Button-label">Add sample text</span>
             </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-font-props" class="ms-Button">
                 <span class="ms-Button-label">Get font properties</span>

--- a/samples/word/50-document/manage-change-tracking.yaml
+++ b/samples/word/50-document/manage-change-tracking.yaml
@@ -89,18 +89,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows basic operations of the Track Changes feature.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample text</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Get current change tracking mode</h4>
             <button id="get-change-tracking-mode" class="ms-Button">

--- a/samples/word/50-document/manage-change-tracking.yaml
+++ b/samples/word/50-document/manage-change-tracking.yaml
@@ -141,11 +141,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-comments.yaml
+++ b/samples/word/50-document/manage-comments.yaml
@@ -298,11 +298,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-comments.yaml
+++ b/samples/word/50-document/manage-comments.yaml
@@ -215,18 +215,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows basic operations using comments.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample text</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Manage comments in selection</h4>
             <p>Select content in document body before proceeding.</p>

--- a/samples/word/50-document/manage-custom-xml-part-ns.yaml
+++ b/samples/word/50-document/manage-custom-xml-part-ns.yaml
@@ -253,12 +253,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, query, replace, edit, and delete a custom XML part in a document.</p>
             <p><b>Note</b>: For your production add-in, make sure to create and host your own XML schema.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-custom-xml-part" class="ms-Button">
             <span class="ms-Button-label">Add XML part</span>

--- a/samples/word/50-document/manage-custom-xml-part-ns.yaml
+++ b/samples/word/50-document/manage-custom-xml-part-ns.yaml
@@ -300,11 +300,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-custom-xml-part.yaml
+++ b/samples/word/50-document/manage-custom-xml-part.yaml
@@ -208,11 +208,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-custom-xml-part.yaml
+++ b/samples/word/50-document/manage-custom-xml-part.yaml
@@ -170,12 +170,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, query, edit, and delete a custom XML part in a document.</p>
           <p><b>Note</b>: For your production add-in, make sure to create and host your own XML schema.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="add-custom-xml-part" class="ms-Button">
             <span class="ms-Button-label">Add XML part</span>

--- a/samples/word/50-document/manage-fields.yaml
+++ b/samples/word/50-document/manage-fields.yaml
@@ -239,11 +239,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-fields.yaml
+++ b/samples/word/50-document/manage-fields.yaml
@@ -173,21 +173,21 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample demonstrates how to manage fields, which are placeholders for dynamic data in your document. To learn
                 more about fields, refer to <a target="_blank"
                     href="https://support.microsoft.com/office/c429bbb0-8669-48a7-bd24-bab6ba6b06bb">Insert, edit, and view
                     fields in Word</a>.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Set up</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Insert fields</h4>
             <p>First, select some text.</p>

--- a/samples/word/50-document/manage-footnotes.yaml
+++ b/samples/word/50-document/manage-footnotes.yaml
@@ -167,18 +167,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows basic operations using footnotes.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample text</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <h4>Insert footnote</h4>
             <p>1. Select text in the document.</p>

--- a/samples/word/50-document/manage-footnotes.yaml
+++ b/samples/word/50-document/manage-footnotes.yaml
@@ -239,11 +239,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-settings.yaml
+++ b/samples/word/50-document/manage-settings.yaml
@@ -121,11 +121,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-settings.yaml
+++ b/samples/word/50-document/manage-settings.yaml
@@ -77,13 +77,13 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to add, edit, get, and delete custom settings on a document. Settings created by an add-in
                 can
                 only be managed by that add-in.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Add a new setting, or edit an existing one</p>
             <div class="ms-TextField">

--- a/samples/word/50-document/manage-styles.yaml
+++ b/samples/word/50-document/manage-styles.yaml
@@ -250,11 +250,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to manage styles.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <h4>Get current number of styles</h4>

--- a/samples/word/50-document/manage-styles.yaml
+++ b/samples/word/50-document/manage-styles.yaml
@@ -341,10 +341,10 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
     core-js@2.4.1/client/core.min.js
     @types/core-js
     jquery@3.1.1

--- a/samples/word/50-document/manage-tracked-changes.yaml
+++ b/samples/word/50-document/manage-tracked-changes.yaml
@@ -205,11 +205,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/manage-tracked-changes.yaml
+++ b/samples/word/50-document/manage-tracked-changes.yaml
@@ -149,18 +149,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample shows how to manage tracked changes.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample text</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="get-all-tracked-changes" class="ms-Button">
             <span class="ms-Button-label">Get all tracked changes</span>
@@ -178,7 +178,7 @@ template:
             <span class="ms-Button-label">Reject the first tracked change</span>
           </button>
         </section>
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <p>First, choose the <b>Add sample text</b> button.
                 <button id="accept-all-tracked-changes" class="ms-Button">
                     <span class="ms-Button-label">Accept all tracked changes</span>

--- a/samples/word/50-document/save-close.yaml
+++ b/samples/word/50-document/save-close.yaml
@@ -133,11 +133,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/50-document/save-close.yaml
+++ b/samples/word/50-document/save-close.yaml
@@ -79,11 +79,11 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to use the options for saving and closing the current document.</p>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <label>File name without extension:</label>

--- a/samples/word/90-scenarios/doc-assembly.yaml
+++ b/samples/word/90-scenarios/doc-assembly.yaml
@@ -119,12 +119,12 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to use the basic document assembly objects. It creates a sample document, searches for text,
             creates a template, and adds paragraphs and footers.
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <button id="insert-header" class="ms-Button">
             <span class="ms-Button-label">Add title</span>

--- a/samples/word/90-scenarios/doc-assembly.yaml
+++ b/samples/word/90-scenarios/doc-assembly.yaml
@@ -165,11 +165,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/90-scenarios/multiple-property-set.yaml
+++ b/samples/word/90-scenarios/multiple-property-set.yaml
@@ -70,18 +70,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows how to format text using the object.set method.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>Set the styling of the first paragraph.</p>
             <button id="set-multiple-properties-with-object" class="ms-Button">

--- a/samples/word/90-scenarios/multiple-property-set.yaml
+++ b/samples/word/90-scenarios/multiple-property-set.yaml
@@ -107,11 +107,11 @@ style:
         }
     language: css
 libraries: |-
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/99-preview-apis/insert-and-change-combo-box-content-control.yaml
+++ b/samples/word/99-preview-apis/insert-and-change-combo-box-content-control.yaml
@@ -319,8 +319,8 @@ libraries: |-
     https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
     @types/office-js-preview
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/99-preview-apis/insert-and-change-combo-box-content-control.yaml
+++ b/samples/word/99-preview-apis/insert-and-change-combo-box-content-control.yaml
@@ -243,18 +243,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to insert, change, and delete combo box content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <span class="ms-font-m">Insert a combo box content control after selected text.</span>

--- a/samples/word/99-preview-apis/insert-and-change-content-controls.yaml
+++ b/samples/word/99-preview-apis/insert-and-change-content-controls.yaml
@@ -198,8 +198,8 @@ libraries: |-
     https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
     @types/office-js-preview
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/99-preview-apis/insert-and-change-content-controls.yaml
+++ b/samples/word/99-preview-apis/insert-and-change-content-controls.yaml
@@ -141,18 +141,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to insert content controls and change their properties.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
               <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <span class="ms-font-m">Insert content controls on each paragraph.</span>
             <button id="insert-controls" class="ms-Button">

--- a/samples/word/99-preview-apis/insert-and-change-dropdown-list-content-control.yaml
+++ b/samples/word/99-preview-apis/insert-and-change-dropdown-list-content-control.yaml
@@ -245,18 +245,18 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             This sample demonstrates how to insert, change, and delete dropdown list content controls.
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Setup</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <span class="ms-font-m">Insert a dropdown list content control after selected text.</span>

--- a/samples/word/99-preview-apis/insert-and-change-dropdown-list-content-control.yaml
+++ b/samples/word/99-preview-apis/insert-and-change-dropdown-list-content-control.yaml
@@ -321,8 +321,8 @@ libraries: |-
     https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
     @types/office-js-preview
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/99-preview-apis/manage-comments.yaml
+++ b/samples/word/99-preview-apis/manage-comments.yaml
@@ -267,21 +267,21 @@ script:
     language: typescript
 template:
     content: |-
-        <section class="ms-font-m">
+        <section class="ms-Fabric ms-font-m">
             <p>This sample shows operations on comments and how to use comment events.</p>
             <p><b>Important</b>: Comment events APIs are currently in preview. If this snippet doesn't work, try using
                 Word
                 on a different platform.</p>
         </section>
 
-        <section class="setup ms-font-m">
+        <section class="ms-Fabric setup ms-font-m">
             <h3>Set up</h3>
             <button id="setup" class="ms-Button">
             <span class="ms-Button-label">Add sample text</span>
           </button>
         </section>
 
-        <section class="samples ms-font-m">
+        <section class="ms-Fabric samples ms-font-m">
             <h3>Try it out</h3>
             <p>
                 <button id="register-event-handlers" class="ms-Button">

--- a/samples/word/99-preview-apis/manage-comments.yaml
+++ b/samples/word/99-preview-apis/manage-comments.yaml
@@ -366,8 +366,8 @@ libraries: |
     https://appsforoffice.microsoft.com/lib/beta/hosted/office.js
     @types/office-js-preview
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js

--- a/samples/word/default.yaml
+++ b/samples/word/default.yaml
@@ -50,11 +50,11 @@ style:
         }
     language: css
 libraries: |
-    https://appsforoffice.microsoft.com/lib/1/hosted/office.js
+    https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js
     @types/office-js
 
-    office-ui-fabric-js@1.4.0/dist/css/fabric.min.css
-    office-ui-fabric-js@1.4.0/dist/css/fabric.components.min.css
+    office-ui-fabric-core@11.1.0/dist/css/fabric.min.css
+    office-ui-fabric-js@1.5.0/dist/css/fabric.components.min.css
 
     core-js@2.4.1/client/core.min.js
     @types/core-js


### PR DESCRIPTION
- Updates Office JS API CDN URL to use version 1.1.
- Updates snippets to use Fabric Core version 11.1.0.
- Updates snippets to use the latest version of Office UI Fabric JS components. (1.5.0).
- Updates applicable HTML files to use the `ms-Fabric` class in response to Fabric Core CDN URL change.

Tested changes on a few snippets in WXPO.