### PR TITLE
Update workflows to use node.js LTS

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -2,6 +2,7 @@ name: auto-publish
 run-name: Automatically publish snippets
 on:
   schedule:
+    # Run at 10:15 AM UTC on Tuesday and Thursday.
     - cron: '15 10 * * TUE'
     - cron: '15 10 * * THU'
 jobs:
@@ -15,7 +16,7 @@ jobs:
         working-directory: ./
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check out main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-node-${{ matrix.node-version }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [lts/*]
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Updated the jobs to use the active LTS version and updated the dependent actions to versions that support the active LTS version. Addresses run warnings.

I did an ad-hoc run of the office-js-docs-reference autogen-docs workflow and found no issues.