### PR TITLE
Fix Word annotation sample selection

### DIFF
--- a/samples/word/50-document/manage-annotations.yaml
+++ b/samples/word/50-document/manage-annotations.yaml
@@ -284,6 +284,11 @@ script:
               "Use add-in commands to extend the Word UI and launch task panes that run JavaScript that interacts with the content in a Word document. Any code that you can run in a browser can run in a Word add-in. Add-ins that interact with content in a Word document create requests to act on Word objects and synchronize object state.",
               "End"
             );
+
+            const firstParagraph: Word.Paragraph = body.paragraphs.getFirst();
+            firstParagraph.select();
+
+            await context.sync();
           });
         }
 


### PR DESCRIPTION
## Summary

- Select the first populated paragraph created by `setup()`.
- Synchronize the queued document changes before the sample's annotation actions run.

## Root cause

Word retains one empty paragraph after `body.clear()`. The sample inserts its two populated paragraphs at `Start` and `End`, leaving the selection in the empty paragraph between them. `insertAnnotations()` then targets that zero-length selected paragraph with critique offsets from 1 through 28, so Word correctly returns HTTP 400 `InvalidArgument` at `Paragraph.insertAnnotations`.

## Validation

- Reproduced the original failure in Word on the web.
- Manually tested the updated `setup()` in Word on the web; the annotation workflow succeeds.
- The modified YAML has no VS Code diagnostics.

Related: OfficeDev/office-js#6645